### PR TITLE
added PLCTYPE_LINT and PLCTYPE_ULINT to plc data types.

### DIFF
--- a/pyads/constants.py
+++ b/pyads/constants.py
@@ -10,7 +10,7 @@
 
 """
 from ctypes import c_bool, c_byte, c_int8, c_uint8, c_int16, c_uint16, \
-    c_int32, c_uint32, c_float, c_double, c_char, c_short
+    c_int32, c_uint32, c_float, c_double, c_char, c_short, c_int64, c_uint64
 
 STRING_BUFFER = 1024
 
@@ -32,6 +32,8 @@ PLCTYPE_UDINT = c_uint32
 PLCTYPE_UINT = c_uint16
 PLCTYPE_USINT = c_uint8
 PLCTYPE_WORD = c_uint16
+PLCTYPE_LINT = c_int64
+PLCTYPE_ULINT = c_uint64
 
 
 def PLCTYPE_ARR_REAL(n):


### PR DESCRIPTION
According to the Beckhoff website the ULINT and LINT are not supported by TwinCAT. I believe this information is outdated because TwinCAT3 programming software does have these types. I ran the following as a test with success. 
`import pyads
from ctypes import c_uint64, c_int64
plc = pyads.Connection('127.0.0.1.1.1',851)
print(plc)
if plc:
    plc.open()
    val = plc.read_by_name('Global.test_lint', c_int64)
    print(val)
    val = plc.read_by_name('Global.test_ulint', c_uint64)
    print(val)` 