### PR TITLE
Change notification decorator to process ctype.Structure objects

### DIFF
--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -11,7 +11,7 @@
 from typing import Optional, Union, Tuple, Any, Type, Callable, Dict
 from datetime import datetime
 import struct
-from ctypes import memmove, addressof, c_ubyte
+from ctypes import memmove, addressof, c_ubyte, Structure
 
 from .utils import platform_is_linux
 from .filetimes import filetime_to_dt
@@ -722,6 +722,10 @@ class Connection(object):
                     # read only until null-termination character
                     value = bytearray(dest).split(b'\0', 1)[0].decode('utf-8')
 
+                elif isinstance(plc_datatype, Structure):
+                    dest = plc_datatype
+                    memmove(addressof(dest), addressof(data), data_size)
+                    value = dest
 
                 elif plc_datatype not in datatype_map:
                     value = data

--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -11,7 +11,7 @@
 from typing import Optional, Union, Tuple, Any, Type, Callable, Dict
 from datetime import datetime
 import struct
-from ctypes import memmove, addressof, c_ubyte, Structure
+from ctypes import memmove, addressof, c_ubyte, Structure, sizeof
 
 from .utils import platform_is_linux
 from .filetimes import filetime_to_dt
@@ -722,10 +722,10 @@ class Connection(object):
                     # read only until null-termination character
                     value = bytearray(dest).split(b'\0', 1)[0].decode('utf-8')
 
-                elif isinstance(plc_datatype, Structure):
-                    dest = plc_datatype
-                    memmove(addressof(dest), addressof(data), data_size)
-                    value = dest
+                elif issubclass(plc_datatype, Structure):
+                    value = plc_datatype()
+                    fit_size = min(data_size, sizeof(value))
+                    memmove(addressof(value), addressof(data), fit_size)
 
                 elif plc_datatype not in datatype_map:
                     value = data


### PR DESCRIPTION
The following commit allows the ability to receive structures in notifications by modifying the decorator.

For example:

```
class TowerEvent(Structure):
    _fields_ = [
        ("Category", c_char * 21),
        ("Name", c_char * 81),
        ("Message", c_char * 81)
    ]

@plc.notification(TowerEvent)
def callback(handle, name, timestamp, value):
    print(f'Received new event notification for {name}.Message = {value.Message}')
```
^^^ Sample code modified to work with the latest commit.

Regards,
David