### PR TITLE
Fix SAdsNotificationHeader structure

### DIFF
--- a/pyads/structs.py
+++ b/pyads/structs.py
@@ -10,7 +10,7 @@
 """
 import typing
 from ctypes import c_byte, c_short, Structure, c_ubyte, c_ushort, c_ulong, \
-    c_ulonglong, POINTER, Union, c_uint32, c_uint64
+    c_ulonglong, Union, c_uint32, c_uint64
 from .constants import ADSTRANS_SERVERONCHA
 
 
@@ -268,13 +268,20 @@ class SAdsNotificationAttrib(Structure):
 
 
 class SAdsNotificationHeader(Structure):
-    """C structure representation of AdsNotificationHeader."""
+    """C structure representation of AdsNotificationHeader.
+
+    :ivar hNotification: notification handle
+    :ivar nTimeStamp: time stamp in FILETIME format
+    :ivar cbSampleSize: number of data bytes
+    :ivar data: variable-length data field, get via ctypes.addressof + offset
+
+    """
 
     _pack_ = 1
     _fields_ = [("hNotification", c_uint32),
                 ("nTimeStamp", c_uint64),
                 ("cbSampleSize", c_uint32),
-                ("data", POINTER(c_ubyte))]
+                ("data", c_ubyte)]
 
 
 class SAdsSymbolUploadInfo(Structure):


### PR DESCRIPTION
The data field is a dynamically sized array that is part of the
structure. As such, declaring it as a pointer type is wrong.
If it is declared as a pointer, `bytearray(data)` is limited in size
to the size of a pointer on the platform Python is running on.
With x86 (32-bit) Python, it is not possible to capture double-
precision floating point values this way, since they are twice
as large as the pointer size. `struct.unpack` will then complain
that the sizes do not match up.
Instead, declare that the data field is one byte (like in the actual
C structure), and dynamically build a field of the right size
when it is known.
This additionally allows to remove the superfluous copy of
the value for string parsing.

This breaks backwards-compatibility when functions relied on
getting a pointer-sized byte array for unmapped types since
they are now also correctly sized.

Fixes #43