### PR TITLE
Linux adding routes to remote PLC

### DIFF
--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -25,10 +25,35 @@ added in the TwinCat Router UI).
 >>> adr = pyads.AmsAddr('127.0.0.1.1.1', pyads.PORT_SPS1)
 >>> pyads.add_route(adr, remote_ip)
 ```
+Another option is to use the Connection class.
+```python
+>>> remote_ip = '192.168.0.100'
+>>> remote_ads = '5.12.82.20.1.1'
+>>> with pyads.Connection(remote_ads, pyads.PORT_SPS1, remote_ip) as plc:
+>>>     plc.read_by_name('.TAG_NAME', pyads.PLCTYPE_INT)
+```
+
 Get the AMS address of the local machine. This may need to be added to
 the routing table of the remote machine.
 **NOTE: On Linux machines at least one route must be added before the call
 to `get_local_address()` will function properly.**
+
+### Adding route to PLC on Linux
+Beckhoff PLCs require that a route be added to the routing table of the PLC. Normally this is handled in the TwinCAT router on Windows, but on Linux there is no such option.
+This only needs to be done once when initially setting up a connection to a remote PLC.
+
+Adding a route to a remote PLC to allow connections to a PC with the Hostname "MyPC"
+``` python
+>>> import pyads
+>>> SENDER_AMS = '1.2.3.4.1.1'
+>>> PLC_IP = '192.168.0.100'
+>>> USERNAME = 'user'
+>>> PASSWORD = 'password'
+>>> ROUTE_NAME = 'RouteToMyPC'
+>>> HOSTNAME = 'MyPC'
+>>> PLC_AMS_ID = '11.22.33.44.1.1'
+>>> pyads.add_route_to_plc(SENDER_AMS, HOSTNAME, PLC_IP, USERNAME, PASSWORD, route_name=ROUTE_NAME)
+```
 
 ### Creating routes on Windows
 

--- a/pyads/__init__.py
+++ b/pyads/__init__.py
@@ -13,7 +13,7 @@ from .structs import AmsAddr, NotificationAttrib
 
 from .ads import open_port, close_port, get_local_address, read_state, \
     write_control, read_device_info, write, read_write, read, \
-    read_by_name, write_by_name, add_route, delete_route, \
+    read_by_name, write_by_name, add_route, add_route_to_plc, delete_route, \
     add_device_notification, del_device_notification, Connection, \
     set_local_address, set_timeout
 

--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -4,8 +4,8 @@
 :license: MIT, see license file or https://opensource.org/licenses/MIT
 
 :created on: 2018-06-11 18:15:53
-:last modified by: Stefan Lehmann
-:last modified time: 2019-03-26 13:57:52
+:last modified by: Adrian Garcia
+:last modified time: 2019-06-12 11:18:00
 
 """
 from typing import Optional, Union, Tuple, Any, Type, Callable, Dict
@@ -18,6 +18,7 @@ from .filetimes import filetime_to_dt
 
 from .pyads_ex import (
     adsAddRoute,
+    adsAddRouteToPLC,
     adsDelRoute,
     adsPortOpenEx,
     adsPortCloseEx,
@@ -338,6 +339,20 @@ def add_route(adr, ip_address):
     """
     return adsAddRoute(adr.netIdStruct(), ip_address)
 
+def add_route_to_plc(sending_net_id, ip_address, username, password, route_name=None, added_net_id=None, sending_host_name=None):
+    # type: (AmsAddr, str, str, str, str, AmsAddr, str) -> None
+    """Embed a new route in the PLC.
+
+    :param pyads.structs.SAmsNetId sending_net_id: sending net id
+    :param str ip_address: ip address of the routing endpoint
+    :param str username: username for PLC
+    :param str password: password for PLC
+    :param str route_name: PLC side name for route, defaults to sending_host_name or the current hostename of this PC
+    :param pyads.structs.SAmsNetId added_net_id: net id that is being added to the PLC, defaults to sending_net_id
+    :param str sending_host_name: host name of sending pc, defaults to hostname of this PC
+
+    """
+    return adsAddRouteToPLC(sending_net_id, ip_address, username, password, route_name=None, added_net_id=None, sending_host_name=None)
 
 def delete_route(adr):
     # type: (AmsAddr) -> None

--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -352,7 +352,7 @@ def add_route_to_plc(sending_net_id, ip_address, username, password, route_name=
     :param str sending_host_name: host name of sending pc, defaults to hostname of this PC
 
     """
-    return adsAddRouteToPLC(sending_net_id, ip_address, username, password, route_name=None, added_net_id=None, sending_host_name=None)
+    return adsAddRouteToPLC(sending_net_id, ip_address, username, password, route_name=route_name, added_net_id=added_net_id, sending_host_name=sending_host_name)
 
 def delete_route(adr):
     # type: (AmsAddr) -> None

--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -339,20 +339,20 @@ def add_route(adr, ip_address):
     """
     return adsAddRoute(adr.netIdStruct(), ip_address)
 
-def add_route_to_plc(adding_net_id, adding_host_name, ip_address, username, password, route_name=None, added_net_id=None):
+def add_route_to_plc(sending_net_id, adding_host_name, ip_address, username, password, route_name=None, added_net_id=None):
     # type: (AmsAddr, str, str, str, str, str, AmsAddr) -> None
     """Embed a new route in the PLC.
 
-    :param pyads.structs.SAmsNetId adding_net_id: sending net id
+    :param pyads.structs.SAmsNetId sending_net_id: sending net id
     :param str adding_host_name: host name (or IP) of the PC being added, defaults to hostname of this PC
     :param str ip_address: ip address of the routing endpoint
     :param str username: username for PLC
     :param str password: password for PLC
     :param str route_name: PLC side name for route, defaults to adding_host_name or the current hostename of this PC
-    :param pyads.structs.SAmsNetId added_net_id: net id that is being added to the PLC, defaults to adding_net_id
+    :param pyads.structs.SAmsNetId added_net_id: net id that is being added to the PLC, defaults to sending_net_id
 
     """
-    return adsAddRouteToPLC(adding_net_id, adding_host_name, ip_address, username, password, route_name=route_name, added_net_id=added_net_id)
+    return adsAddRouteToPLC(sending_net_id, adding_host_name, ip_address, username, password, route_name=route_name, added_net_id=added_net_id)
 
 def delete_route(adr):
     # type: (AmsAddr) -> None

--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -339,20 +339,20 @@ def add_route(adr, ip_address):
     """
     return adsAddRoute(adr.netIdStruct(), ip_address)
 
-def add_route_to_plc(sending_net_id, ip_address, username, password, route_name=None, added_net_id=None, adding_host_name=None):
-    # type: (AmsAddr, str, str, str, str, AmsAddr, str) -> None
+def add_route_to_plc(adding_net_id, adding_host_name, ip_address, username, password, route_name=None, added_net_id=None):
+    # type: (AmsAddr, str, str, str, str, str, AmsAddr) -> None
     """Embed a new route in the PLC.
 
-    :param pyads.structs.SAmsNetId sending_net_id: sending net id
+    :param pyads.structs.SAmsNetId adding_net_id: sending net id
+    :param str adding_host_name: host name (or IP) of the PC being added, defaults to hostname of this PC
     :param str ip_address: ip address of the routing endpoint
     :param str username: username for PLC
     :param str password: password for PLC
     :param str route_name: PLC side name for route, defaults to adding_host_name or the current hostename of this PC
-    :param pyads.structs.SAmsNetId added_net_id: net id that is being added to the PLC, defaults to sending_net_id
-    :param str adding_host_name: host name of the PC being added, defaults to hostname of this PC
+    :param pyads.structs.SAmsNetId added_net_id: net id that is being added to the PLC, defaults to adding_net_id
 
     """
-    return adsAddRouteToPLC(sending_net_id, ip_address, username, password, route_name=route_name, added_net_id=added_net_id, adding_host_name=adding_host_name)
+    return adsAddRouteToPLC(adding_net_id, adding_host_name, ip_address, username, password, route_name=route_name, added_net_id=added_net_id)
 
 def delete_route(adr):
     # type: (AmsAddr) -> None

--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -339,7 +339,7 @@ def add_route(adr, ip_address):
     """
     return adsAddRoute(adr.netIdStruct(), ip_address)
 
-def add_route_to_plc(sending_net_id, ip_address, username, password, route_name=None, added_net_id=None, sending_host_name=None):
+def add_route_to_plc(sending_net_id, ip_address, username, password, route_name=None, added_net_id=None, adding_host_name=None):
     # type: (AmsAddr, str, str, str, str, AmsAddr, str) -> None
     """Embed a new route in the PLC.
 
@@ -347,12 +347,12 @@ def add_route_to_plc(sending_net_id, ip_address, username, password, route_name=
     :param str ip_address: ip address of the routing endpoint
     :param str username: username for PLC
     :param str password: password for PLC
-    :param str route_name: PLC side name for route, defaults to sending_host_name or the current hostename of this PC
+    :param str route_name: PLC side name for route, defaults to adding_host_name or the current hostename of this PC
     :param pyads.structs.SAmsNetId added_net_id: net id that is being added to the PLC, defaults to sending_net_id
-    :param str sending_host_name: host name of sending pc, defaults to hostname of this PC
+    :param str adding_host_name: host name of the PC being added, defaults to hostname of this PC
 
     """
-    return adsAddRouteToPLC(sending_net_id, ip_address, username, password, route_name=route_name, added_net_id=added_net_id, sending_host_name=sending_host_name)
+    return adsAddRouteToPLC(sending_net_id, ip_address, username, password, route_name=route_name, added_net_id=added_net_id, adding_host_name=adding_host_name)
 
 def delete_route(adr):
     # type: (AmsAddr) -> None

--- a/pyads/pyads_ex.py
+++ b/pyads/pyads_ex.py
@@ -175,7 +175,7 @@ def adsAddRouteToPLC(sending_net_id, ip_address, username, password, route_name=
 
     # The head of the UDP AMS packet containing host routing information
     data_header = (0x036614710000000006000000).to_bytes(12, 'big')
-    data_header +=	bytes(map(int, sending_net_id.split('.')))		# Sending net ID
+    data_header += bytes(map(int, sending_net_id.split('.')))		# Sending net ID
     data_header += (10000).to_bytes(2, 'little')					# Internal communication port?
     data_header += (0x0500).to_bytes(2, 'big')						# Write command
     data_header += (0x00000c00).to_bytes(4, 'big')					# Block of unknown
@@ -188,7 +188,7 @@ def adsAddRouteToPLC(sending_net_id, ip_address, username, password, route_name=
     actual_data += bytes(map(int, added_net_id.split('.')))			# Net ID being added to the PLC
     actual_data += (0x0d00).to_bytes(2, 'big')						# Block of unknown (maybe encryption?)
     actual_data += len(username).to_bytes(2, 'little')				# Length of the user name field
-    actual_data +=	username.encode('utf-8')						# PLC Username
+    actual_data += username.encode('utf-8')						# PLC Username
     actual_data += (0x0200).to_bytes(2, 'big')						# Block of unknown
     actual_data += len(password).to_bytes(2, 'little')				# Length of password field
     actual_data += password.encode('utf-8')							# PLC Password
@@ -225,9 +225,10 @@ def adsAddRouteToPLC(sending_net_id, ip_address, username, password, route_name=
    
     if int.from_bytes(rcvd_is_password_correct, 'big') == 0x040000:
         return True
-    else:
+    elif int.from_bytes(rcvd_is_password_correct, 'big') == 0x000407:
         return False
-    
+    else:
+        return None 
 
 @router_function
 def adsDelRoute(net_id):

--- a/pyads/pyads_ex.py
+++ b/pyads/pyads_ex.py
@@ -224,13 +224,14 @@ def adsAddRouteToPLC(sending_net_id, ip_address, username, password, route_name=
         rcvd_command_code = data[20:22]						# Command code (should be read) Little endian
         rcvd_protocol_block = data[22:]						# Unknown block of protocol
         rcvd_is_password_correct = rcvd_protocol_block[4:7]	# 0x040000 when password was correct, 0x000407 when it was incorrect
-   
-    if rcvd_is_password_correct == b'\x04\x00\x00':
-        return True
-    elif rcvd_is_password_correct == b'\x00\x04\x07':
-        return False
-    else:
-        raise ValueError('Received unknown response from ' + ip_address)
+
+        if rcvd_is_password_correct == b'\x04\x00\x00':
+            return True
+        elif rcvd_is_password_correct == b'\x00\x04\x07':
+            return False
+    
+	# If we fell through the whole way to the bottom, then we got a weird response
+    raise RuntimeError("Unexpected response from PLC")
 
 @router_function
 def adsDelRoute(net_id):

--- a/pyads/pyads_ex.py
+++ b/pyads/pyads_ex.py
@@ -151,7 +151,7 @@ def adsAddRoute(net_id, ip_address):
         raise ADSError(error_code)
 
 @router_function
-def adsAddRouteToPLC(sending_net_id, ip_address, username, password, route_name=None, added_net_id=None, sending_host_name=None):
+def adsAddRouteToPLC(sending_net_id, ip_address, username, password, route_name=None, added_net_id=None, adding_host_name=None):
     # type: (AmsAddr, str, str, str, str, AmsAddr, str) -> None
     """Embed a new route in the PLC. Returns true if successful
 
@@ -159,16 +159,16 @@ def adsAddRouteToPLC(sending_net_id, ip_address, username, password, route_name=
     :param str ip_address: ip address of the routing endpoint
     :param str username: username for PLC
     :param str password: password for PLC
-    :param str route_name: PLC side name for route, defaults to sending_host_name or the current hostename of this PC
+    :param str route_name: PLC side name for route, defaults to adding_host_name or the current hostename of this PC
     :param pyads.structs.SAmsNetId added_net_id: net id that is being added to the PLC, defaults to sending_net_id
-    :param str sending_host_name: host name of sending pc, defaults to hostname of this PC
+    :param str adding_host_name: host name of the PC being added, defaults to hostname of this PC
 
     """
     import socket
     # ALL SENT STRINGS MUST BE NULL TERMINATED
-    sending_host_name = sending_host_name + '\0' if sending_host_name else socket.gethostname() + '\0'
+    adding_host_name = adding_host_name + '\0' if adding_host_name else socket.gethostname() + '\0'
     added_net_id = added_net_id if added_net_id else sending_net_id
-    route_name = route_name + '\0' if route_name else sending_host_name
+    route_name = route_name + '\0' if route_name else adding_host_name
 
     username = username + '\0'
     password = password + '\0'
@@ -179,8 +179,8 @@ def adsAddRouteToPLC(sending_net_id, ip_address, username, password, route_name=
     data_header += PORT_SYSTEMSERVICE.to_bytes(2, 'little')			# Internal communication port
     data_header += (0x0500).to_bytes(2, 'big')						# Write command
     data_header += (0x00000c00).to_bytes(4, 'big')					# Block of unknown
-    data_header += len(sending_host_name).to_bytes(2, 'little')		# Length of sender host name
-    data_header += sending_host_name.encode('utf-8')				# Sender host name
+    data_header += len(adding_host_name).to_bytes(2, 'little')		# Length of sender host name
+    data_header += adding_host_name.encode('utf-8')				# Sender host name
     data_header += (0x0700).to_bytes(2, 'big')						# Block of unknown
 
 

--- a/pyads/pyads_ex.py
+++ b/pyads/pyads_ex.py
@@ -168,6 +168,7 @@ def adsAddRouteToPLC(sending_net_id, adding_host_name, ip_address, username, pas
     import struct
     from contextlib import closing
     # ALL SENT STRINGS MUST BE NULL TERMINATED
+    adding_host_name += '\0'
     added_net_id = added_net_id if added_net_id else sending_net_id
     route_name = route_name + '\0' if route_name else adding_host_name
 

--- a/pyads/pyads_ex.py
+++ b/pyads/pyads_ex.py
@@ -151,17 +151,17 @@ def adsAddRoute(net_id, ip_address):
         raise ADSError(error_code)
 
 @router_function
-def adsAddRouteToPLC(sending_net_id, ip_address, username, password, route_name=None, added_net_id=None, adding_host_name=None):
-    # type: (AmsAddr, str, str, str, str, AmsAddr, str) -> None
-    """Embed a new route in the PLC. Returns true if successful
+def adsAddRouteToPLC(adding_net_id, adding_host_name, ip_address, username, password, route_name=None, added_net_id=None):
+    # type: (AmsAddr, str, str, str, str, str, AmsAddr) -> None
+    """Embed a new route in the PLC.
 
-    :param pyads.structs.SAmsNetId sending_net_id: sending net id
+    :param pyads.structs.SAmsNetId adding_net_id: sending net id
+    :param str adding_host_name: host name (or IP) of the PC being added, defaults to hostname of this PC
     :param str ip_address: ip address of the routing endpoint
     :param str username: username for PLC
     :param str password: password for PLC
     :param str route_name: PLC side name for route, defaults to adding_host_name or the current hostename of this PC
-    :param pyads.structs.SAmsNetId added_net_id: net id that is being added to the PLC, defaults to sending_net_id
-    :param str adding_host_name: host name of the PC being added, defaults to hostname of this PC
+    :param pyads.structs.SAmsNetId added_net_id: net id that is being added to the PLC, defaults to adding_net_id
 
     """
     import socket
@@ -169,7 +169,7 @@ def adsAddRouteToPLC(sending_net_id, ip_address, username, password, route_name=
     from contextlib import closing
     # ALL SENT STRINGS MUST BE NULL TERMINATED
     adding_host_name = adding_host_name + '\0' if adding_host_name else socket.gethostname() + '\0'
-    added_net_id = added_net_id if added_net_id else sending_net_id
+    added_net_id = added_net_id if added_net_id else adding_net_id
     route_name = route_name + '\0' if route_name else adding_host_name
 
     username = username + '\0'
@@ -177,7 +177,7 @@ def adsAddRouteToPLC(sending_net_id, ip_address, username, password, route_name=
 
     # The head of the UDP AMS packet containing host routing information
     data_header = struct.pack('>12s', b'\x03\x66\x14\x71\x00\x00\x00\x00\x06\x00\x00\x00')
-    data_header += bytes(map(int, sending_net_id.split('.')))		# Sending net ID
+    data_header += bytes(map(int, adding_net_id.split('.')))		# Sending net ID
     data_header += struct.pack('<H', PORT_SYSTEMSERVICE)			# Internal communication port
     data_header += struct.pack('>2s', b'\x05\x00')					# Write command
     data_header += struct.pack('>4s', b'\x00\x00\x0c\x00')			# Block of unknown

--- a/pyads/pyads_ex.py
+++ b/pyads/pyads_ex.py
@@ -149,6 +149,22 @@ def adsAddRoute(net_id, ip_address):
     if error_code:
         raise ADSError(error_code)
 
+@router_function
+def adsAddRouteToPLC(sending_net_id, ip_address, username, password, route_name, added_net_id=None, sending_host_name=None):
+    # type: (SAmsNetId, str) -> None
+    """Embed a new route in the PLC.
+
+    :param pyads.structs.SAmsNetId sending_net_id: sending net id
+    :param str ip_address: ip address of the routing endpoint
+    :param str username: username for PLC
+    :param str password: password for PLC
+    :param str route_name: PLC side name for route
+    :param pyads.structs.SAmsNetId added_net_id: net id that is being added to the PLC, defaults to sending_net_id
+    :param ste sending_host_name: host name of sending pc, defaults to hostname
+
+    """
+    return
+    
 
 @router_function
 def adsDelRoute(net_id):

--- a/pyads/pyads_ex.py
+++ b/pyads/pyads_ex.py
@@ -151,25 +151,24 @@ def adsAddRoute(net_id, ip_address):
         raise ADSError(error_code)
 
 @router_function
-def adsAddRouteToPLC(adding_net_id, adding_host_name, ip_address, username, password, route_name=None, added_net_id=None):
+def adsAddRouteToPLC(sending_net_id, adding_host_name, ip_address, username, password, route_name=None, added_net_id=None):
     # type: (AmsAddr, str, str, str, str, str, AmsAddr) -> None
     """Embed a new route in the PLC.
 
-    :param pyads.structs.SAmsNetId adding_net_id: sending net id
+    :param pyads.structs.SAmsNetId sending_net_id: sending net id
     :param str adding_host_name: host name (or IP) of the PC being added, defaults to hostname of this PC
     :param str ip_address: ip address of the routing endpoint
     :param str username: username for PLC
     :param str password: password for PLC
     :param str route_name: PLC side name for route, defaults to adding_host_name or the current hostename of this PC
-    :param pyads.structs.SAmsNetId added_net_id: net id that is being added to the PLC, defaults to adding_net_id
+    :param pyads.structs.SAmsNetId added_net_id: net id that is being added to the PLC, defaults to sending_net_id
 
     """
     import socket
     import struct
     from contextlib import closing
     # ALL SENT STRINGS MUST BE NULL TERMINATED
-    adding_host_name = adding_host_name + '\0' if adding_host_name else socket.gethostname() + '\0'
-    added_net_id = added_net_id if added_net_id else adding_net_id
+    added_net_id = added_net_id if added_net_id else sending_net_id
     route_name = route_name + '\0' if route_name else adding_host_name
 
     username = username + '\0'
@@ -177,7 +176,7 @@ def adsAddRouteToPLC(adding_net_id, adding_host_name, ip_address, username, pass
 
     # The head of the UDP AMS packet containing host routing information
     data_header = struct.pack('>12s', b'\x03\x66\x14\x71\x00\x00\x00\x00\x06\x00\x00\x00')
-    data_header += bytes(map(int, adding_net_id.split('.')))		# Sending net ID
+    data_header += bytes(map(int, sending_net_id.split('.')))		# Sending net ID
     data_header += struct.pack('<H', PORT_SYSTEMSERVICE)			# Internal communication port
     data_header += struct.pack('>2s', b'\x05\x00')					# Write command
     data_header += struct.pack('>4s', b'\x00\x00\x0c\x00')			# Block of unknown

--- a/pyads/pyads_ex.py
+++ b/pyads/pyads_ex.py
@@ -228,7 +228,7 @@ def adsAddRouteToPLC(sending_net_id, ip_address, username, password, route_name=
     elif int.from_bytes(rcvd_is_password_correct, 'big') == 0x000407:
         return False
     else:
-        return None 
+        raise ValueError('Received unknown response from ' + ip_address)
 
 @router_function
 def adsDelRoute(net_id):

--- a/pyads/pyads_ex.py
+++ b/pyads/pyads_ex.py
@@ -34,6 +34,7 @@ from .constants import (
     PLCTYPE_UDINT,
     ADSIGRP_SYM_VALBYHND,
     ADSIGRP_SYM_RELEASEHND,
+	PORT_SYSTEMSERVICE
 )
 from .errorcodes import ERROR_CODES
 
@@ -164,7 +165,6 @@ def adsAddRouteToPLC(sending_net_id, ip_address, username, password, route_name=
 
     """
     import socket
-
     # ALL SENT STRINGS MUST BE NULL TERMINATED
     sending_host_name = sending_host_name + '\0' if sending_host_name else socket.gethostname() + '\0'
     added_net_id = added_net_id if added_net_id else sending_net_id
@@ -176,7 +176,7 @@ def adsAddRouteToPLC(sending_net_id, ip_address, username, password, route_name=
     # The head of the UDP AMS packet containing host routing information
     data_header = (0x036614710000000006000000).to_bytes(12, 'big')
     data_header += bytes(map(int, sending_net_id.split('.')))		# Sending net ID
-    data_header += (10000).to_bytes(2, 'little')					# Internal communication port?
+    data_header += PORT_SYSTEMSERVICE.to_bytes(2, 'little')			# Internal communication port
     data_header += (0x0500).to_bytes(2, 'big')						# Write command
     data_header += (0x00000c00).to_bytes(4, 'big')					# Block of unknown
     data_header += len(sending_host_name).to_bytes(2, 'little')		# Length of sender host name
@@ -188,7 +188,7 @@ def adsAddRouteToPLC(sending_net_id, ip_address, username, password, route_name=
     actual_data += bytes(map(int, added_net_id.split('.')))			# Net ID being added to the PLC
     actual_data += (0x0d00).to_bytes(2, 'big')						# Block of unknown (maybe encryption?)
     actual_data += len(username).to_bytes(2, 'little')				# Length of the user name field
-    actual_data += username.encode('utf-8')						# PLC Username
+    actual_data += username.encode('utf-8')							# PLC Username
     actual_data += (0x0200).to_bytes(2, 'big')						# Block of unknown
     actual_data += len(password).to_bytes(2, 'little')				# Length of password field
     actual_data += password.encode('utf-8')							# PLC Password

--- a/tests/test_plc_route.py
+++ b/tests/test_plc_route.py
@@ -134,7 +134,7 @@ class PLCRouteTestCase(unittest.TestCase):
 
             # Try to set up a route with ourselves using all the optionals
             try:
-                result = add_route_to_plc(self.SENDER_AMS, self.PLC_IP, self.USERNAME, self.PASSWORD, route_name=self.ROUTE_NAME, added_net_id=self.ADDING_AMS_ID, sending_host_name=self.HOSTNAME)
+                result = add_route_to_plc(self.SENDER_AMS, self.PLC_IP, self.USERNAME, self.PASSWORD, route_name=self.ROUTE_NAME, added_net_id=self.ADDING_AMS_ID, adding_host_name=self.HOSTNAME)
             except:
                 result = None
 
@@ -149,7 +149,7 @@ class PLCRouteTestCase(unittest.TestCase):
 
             # Try to set up a route with ourselves using all the optionals AND an incorrect password
             try:
-                result = add_route_to_plc(self.SENDER_AMS, self.PLC_IP, self.USERNAME, 'Incorrect Password', route_name=self.ROUTE_NAME, added_net_id=self.ADDING_AMS_ID, sending_host_name=self.HOSTNAME)
+                result = add_route_to_plc(self.SENDER_AMS, self.PLC_IP, self.USERNAME, 'Incorrect Password', route_name=self.ROUTE_NAME, added_net_id=self.ADDING_AMS_ID, adding_host_name=self.HOSTNAME)
             except:
                 result = None
 

--- a/tests/test_plc_route.py
+++ b/tests/test_plc_route.py
@@ -1,3 +1,6 @@
+import unittest
+import threading
+import socket
 import struct
 from contextlib import closing
 from pyads import add_route_to_plc

--- a/tests/test_plc_route.py
+++ b/tests/test_plc_route.py
@@ -1,0 +1,159 @@
+import unittest
+import threading
+import socket
+from pyads import add_route_to_plc
+from pyads.utils import platform_is_linux
+
+class PLCRouteTestCase(unittest.TestCase):
+
+    SENDER_AMS = '1.2.3.4.1.1'
+    PLC_IP = '127.0.0.1'
+    USERNAME = 'user'
+    PASSWORD = 'password'
+    ROUTE_NAME = 'Route'
+    ADDING_AMS_ID = '5.6.7.8.1.1'
+    HOSTNAME = 'Host'
+    PLC_AMS_ID = '11.22.33.44.1.1'
+
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def plc_route_reciever(self):
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock: # UDP
+            # Listen on 48899 for communication
+            sock.bind(('', 48899))
+
+            # Keep looping until we get an add address packet
+            addr = [0]
+            while addr[0] != self.PLC_IP:
+                data, addr = sock.recvfrom(1024)
+
+            # Decipher data and 'add route'
+            data = data[12:]													# Remove our data header
+
+            sending_ams_bytes = data[:6]										# Sending AMS address
+            sending_ams = '.'.join([str(int.from_bytes(sending_ams_bytes[i:i+1], 'big')) for i in range(0, len(sending_ams_bytes), 1)])
+            data = data[6:]
+
+            comm_port = int.from_bytes(data[:2], 'little')						# Internal communication port (PORT_SYSTEMSERVICE)
+            data = data[2:]
+
+            command_code = int.from_bytes(data[:2], 'little')					# Comand code to write to PLC
+            data = data[2:]
+            
+            data = data[4:]														# Remove protocol bytes
+            
+            len_sending_host = int.from_bytes(data[:2], 'little')				# Length of host name
+            data = data[2:]
+            
+            hostname = data[:len_sending_host].decode('utf-8')					# Null terminated hostname
+            data = data[len_sending_host:]
+            
+            data = data[2:]														# Remove protocol bytes
+            
+            len_ams_id = int.from_bytes(data[:2], 'little')						# Length of adding AMS ID
+            data = data[2:]
+            
+            adding_ams_id_bytes  = data[:len_ams_id]							# AMS ID being added to PLC
+            adding_ams_id = '.'.join([str(int.from_bytes(adding_ams_id_bytes[i:i+1], 'big')) for i in range(0, len(adding_ams_id_bytes), 1)])
+            data = data[len_ams_id:]
+            
+            data = data[2:]														# Remove protocol bytes
+            
+            len_username = int.from_bytes(data[:2], 'little')					# Length of PLC username
+            data = data[2:]
+            
+            username = data[:len_username].decode('utf-8')						# Null terminated username
+            data = data[len_username:]
+            
+            data = data[2:]														# Remove protocol bytes
+            
+            len_password = int.from_bytes(data[:2], 'little')					# Length of PLC password
+            data = data[2:]
+            
+            password = data[:len_password].decode('utf-8')						# Null terminated username
+            data = data[len_password:]
+            
+            data = data[2:]														# Remove protocol bytes
+            
+            len_route_name = int.from_bytes(data[:2], 'little')					# Length of PLC password
+            data = data[2:]
+
+            route_name = data[:len_route_name].decode('utf-8')					# Null terminated username
+            data = data[len_route_name:]
+
+            self.assertEqual(len(data), 0)										# We should have popped everything from data
+            self.assertEqual(sending_ams, self.SENDER_AMS)
+            self.assertEqual(comm_port, 10000)
+            self.assertEqual(command_code, 5)
+            self.assertEqual(len_sending_host, len(self.HOSTNAME) + 1)			# +1 for the null terminator
+            self.assertEqual(hostname, self.HOSTNAME + '\0')
+            self.assertEqual(adding_ams_id, self.ADDING_AMS_ID)
+            self.assertEqual(len_username, len(self.USERNAME) + 1)				# +1 for the null terminator
+            self.assertEqual(username, self.USERNAME + '\0')
+
+            # Don't check the password since that's part the correct/incorrect response test
+            # We can also assume that if the data after the password is correct, then the password was sent/read correctly
+            #self.assertEqual(len_password, len(self.PASSWORD) + 1)				# +1 for the null terminator
+            #self.assertEqual(password, self.PASSWORD + '\0')
+            
+            self.assertEqual(len_route_name, len(self.ROUTE_NAME) + 1)			# +1 for the null terminator
+            self.assertEqual(route_name, self.ROUTE_NAME + '\0')
+
+            if password == self.PASSWORD + '\0':
+                password_correct = True
+            else:
+                password_correct = False
+
+            # Build response
+            response = (0x036614710000000006000080).to_bytes(12, 'big')			# Same header as being sent to the PLC, but with 80 at the end
+            response += bytes(map(int, self.PLC_AMS_ID.split('.')))					# PLC AMS id
+            response += (10000).to_bytes(2, 'little')							# Internal communication port (PORT_SYSTEMSERVICE)
+            response += (0x0100).to_bytes(2, 'big')								# Command code read
+            response += (0x00000104).to_bytes(4, 'big')							# Block of unknown protocol
+            if password_correct:
+                response += (0x040000).to_bytes(3, 'big')						# Password Correct
+            else:
+                response += (0x000407).to_bytes(3, 'big')						# Password Incorrect
+            response += (0x000000).to_bytes(2, 'big')							# Block of unknown protocol
+            print(response)
+
+            # Send our response to 55189
+            sock.sendto(response, (self.PLC_IP, 55189))
+
+    def test_correct_route(self):
+        if platform_is_linux():
+        # Start receiving listener
+            route_thread = threading.Thread(target=self.plc_route_reciever)
+            route_thread.setDaemon(True)
+            route_thread.start()
+
+            # Try to set up a route with ourselves using all the optionals
+            try:
+                result = add_route_to_plc(self.SENDER_AMS, self.PLC_IP, self.USERNAME, self.PASSWORD, route_name=self.ROUTE_NAME, added_net_id=self.ADDING_AMS_ID, sending_host_name=self.HOSTNAME)
+            except:
+                result = None
+
+            self.assertTrue(result)
+
+    def test_incorrect_route(self):
+        if platform_is_linux():
+            # Start receiving listener
+            route_thread = threading.Thread(target=self.plc_route_reciever)
+            route_thread.setDaemon(True)
+            route_thread.start()
+
+            # Try to set up a route with ourselves using all the optionals AND an incorrect password
+            try:
+                result = add_route_to_plc(self.SENDER_AMS, self.PLC_IP, self.USERNAME, 'Incorrect Password', route_name=self.ROUTE_NAME, added_net_id=self.ADDING_AMS_ID, sending_host_name=self.HOSTNAME)
+            except:
+                result = None
+
+            self.assertFalse(result)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_plc_route.py
+++ b/tests/test_plc_route.py
@@ -135,7 +135,7 @@ class PLCRouteTestCase(unittest.TestCase):
 
             # Try to set up a route with ourselves using all the optionals
             try:
-                result = add_route_to_plc(self.SENDER_AMS, self.PLC_IP, self.USERNAME, self.PASSWORD, route_name=self.ROUTE_NAME, added_net_id=self.ADDING_AMS_ID, adding_host_name=self.HOSTNAME)
+                result = add_route_to_plc(self.SENDER_AMS, self.HOSTNAME, self.PLC_IP, self.USERNAME, self.PASSWORD, route_name=self.ROUTE_NAME, added_net_id=self.ADDING_AMS_ID)
             except:
                 result = None
 
@@ -150,7 +150,7 @@ class PLCRouteTestCase(unittest.TestCase):
 
             # Try to set up a route with ourselves using all the optionals AND an incorrect password
             try:
-                result = add_route_to_plc(self.SENDER_AMS, self.PLC_IP, self.USERNAME, 'Incorrect Password', route_name=self.ROUTE_NAME, added_net_id=self.ADDING_AMS_ID, adding_host_name=self.HOSTNAME)
+                result = add_route_to_plc(self.SENDER_AMS, self.HOSTNAME, self.PLC_IP, self.USERNAME, 'Incorrect Password', route_name=self.ROUTE_NAME, added_net_id=self.ADDING_AMS_ID)
             except:
                 result = None
 


### PR DESCRIPTION
It's a little bare bones, doesn't have tests, and could probably do with some more work, but it successfully adds a route to the remote PLC on demand. I made these modifications for a project I was working on and I figured I'd share.

A rough breakdown of the data structure:
![image](https://user-images.githubusercontent.com/1719461/61139513-72875700-a497-11e9-957a-4d619e6e5f4a.png)


Would love some feedback.