### PR TITLE
added function 'read_structure_by_name'

### DIFF
--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -208,7 +208,7 @@ Then you can read the structure:
 
 ```python
 >>> plc.read_structure_by_name('global.sample_structure', structure_def)
-[11.1, 22.2, 3, 4, 44, 444, 'abc']
+OrderedDict([('rVar': 11.1), ('rVar2': 22.2), ('iVar': 3), ('iVar2': [4, 44, 444]), ('sVar': 'abc')])
 ```
 
 ### Read and write values by address

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -126,13 +126,10 @@ For reading strings the maximum buffer length is 1024.
 'abc'
 ```
 
-### Read and write arrays or structures by name
+### Read and write arrays by name
 
-You can also read/write arrays and structures. For this you simply need to multiply the datatype by
-the number of elements in the array or structure you want to read/write. Only structures made up of
-the same datatype can be used.
-
-**Arrays**
+You can also read/write arrays. For this you simply need to multiply the datatype by
+the number of elements in the array or structure you want to read/write. 
 
 ```python
 >>> plc.write_by_name('global.sample_array', [1, 2, 3], pyads.PLCTYPE_INT * 3)
@@ -146,7 +143,9 @@ the same datatype can be used.
 5
 ```
 
-**Structures**
+### Read and write structures by name
+
+#### Structures of the same datatype
 
 TwinCAT declaration:
 ```
@@ -173,6 +172,43 @@ Python code:
 >>> plc.write_by_name('global.sample_structure.rVar2', 1234.5, pyads.PLCTYPE_LREAL)
 >>> plc.read_by_name('global.sample_structure.rVar2', pyads.PLCTYPE_LREAL)
 1234.5
+```
+
+#### Structures with multiple datatypes (_read only_)
+
+TwinCAT declaration:
+```
+{attribute 'pack mode' := 1}
+TYPE sample_structure :
+STRUCT
+	rVar : LREAL;
+	rVar2 : REAL;
+	iVar : INT;
+	iVar2 : ARRAY [1..3] OF DINT;
+    sVar : STRING;
+END_STRUCT
+END_TYPE
+```
+
+Python code:
+
+First you must declare a tuple which defines the PLC structure. This should match the order
+as declared in the PLC.
+
+```python
+>>> structure_def = (
+...    ('rVar', pyads.PLCTYPE_LREAL, 1),
+...    ('rVar2', pyads.PLCTYPE_REAL, 1),
+...    ('iVar', pyads.PLCTYPE_INT, 1),
+...    ('iVar2', pyads.PLCTYPE_DINT, 3),
+...    ('sVar', pyads.PLCTYPE_STRING, 1))
+```
+
+Then you can read the structure:
+
+```python
+>>> plc.read_structure_by_name('global.sample_structure', structure_def)
+[11.1, 22.2, 3, 4, 44, 444, 'abc']
 ```
 
 ### Read and write values by address

--- a/pyads/__init__.py
+++ b/pyads/__init__.py
@@ -15,7 +15,7 @@ from .ads import open_port, close_port, get_local_address, read_state, \
     write_control, read_device_info, write, read_write, read, \
     read_by_name, write_by_name, add_route, add_route_to_plc, delete_route, \
     add_device_notification, del_device_notification, Connection, \
-    set_local_address, set_timeout, size_of_structure, list_from_bytes
+    set_local_address, set_timeout, size_of_structure, dict_from_bytes
 
 from .pyads_ex import ADSError
 

--- a/pyads/__init__.py
+++ b/pyads/__init__.py
@@ -15,7 +15,7 @@ from .ads import open_port, close_port, get_local_address, read_state, \
     write_control, read_device_info, write, read_write, read, \
     read_by_name, write_by_name, add_route, add_route_to_plc, delete_route, \
     add_device_notification, del_device_notification, Connection, \
-    set_local_address, set_timeout
+    set_local_address, set_timeout, size_of_structure, list_from_bytes
 
 from .pyads_ex import ADSError
 
@@ -24,7 +24,8 @@ from .constants import PLCTYPE_BOOL, PLCTYPE_BYTE, PLCTYPE_DATE, \
     PLCTYPE_REAL, PLCTYPE_SINT, PLCTYPE_STRING, PLCTYPE_TIME, PLCTYPE_TOD, \
     PLCTYPE_UDINT, PLCTYPE_UINT, PLCTYPE_USINT, PLCTYPE_WORD, \
     PLCTYPE_ARR_DINT, PLCTYPE_ARR_INT, PLCTYPE_ARR_LREAL, PLCTYPE_ARR_REAL, \
-    PLCTYPE_ARR_SHORT
+    PLCTYPE_ARR_SHORT, PLC_8_BYTE_TYPES, PLC_4_BYTE_TYPES, PLC_2_BYTE_TYPES, \
+    PLC_BYTE_TYPES, PLC_DEFAULT_STRING_SIZE, DATATYPE_MAP
 
 from .constants import PORT_EVENTLOGGER, PORT_IO, PORT_LOGGER, PORT_NC, \
     PORT_NOCKE, PORT_SCOPE, PORT_SPECIALTASK1, PORT_SPECIALTASK2, PORT_SPS1, \

--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -61,7 +61,7 @@ from .constants import (
     PLC_4_BYTE_TYPES,
     PLC_8_BYTE_TYPES,
     PLC_DEFAULT_STRING_SIZE,
-    DATATYPE_MAP
+    DATATYPE_MAP,
 )
 
 from .structs import AmsAddr, SAmsNetId, AdsVersion, NotificationAttrib, SAdsNotificationHeader
@@ -425,7 +425,7 @@ def set_timeout(ms):
 
 
 def size_of_structure(structure_def):
-    """Calculate the size of a structure in number of BYTEs
+    """Calculate the size of a structure in number of BYTEs.
 
     :param tuple structure_def: special tuple defining the structure and
             types contained within it according o PLCTYPE constants
@@ -461,37 +461,29 @@ def size_of_structure(structure_def):
             var, plc_datatype, size = item
             str_len = None
         except ValueError:
-            try:
-                var, plc_datatype, size, str_len = item
-            except Exception as e:
-                raise RuntimeError(
-                    'Can not calculate structure size, check structure definition') from e
+            var, plc_datatype, size, str_len = item
 
-        try:
-            if plc_datatype == PLCTYPE_STRING:
-                if str_len is not None:
-                    num_of_bytes += ((str_len + 1) * size)
-                else:
-                    num_of_bytes += ((PLC_DEFAULT_STRING_SIZE + 1) * size)
-            elif plc_datatype in PLC_8_BYTE_TYPES:
-                num_of_bytes += (8 * size)
-            elif plc_datatype in PLC_4_BYTE_TYPES:
-                num_of_bytes += (4 * size)
-            elif plc_datatype in PLC_2_BYTE_TYPES:
-                num_of_bytes += (2 * size)
-            elif plc_datatype in PLC_BYTE_TYPES:
-                num_of_bytes += (1 * size)
+        if plc_datatype == PLCTYPE_STRING:
+            if str_len is not None:
+                num_of_bytes += ((str_len + 1) * size)
             else:
-                raise RuntimeError('Datatype not found')
-        except Exception as e:
-            raise RuntimeError(
-                'Can not calculate structure size, check structure definition') from e
+                num_of_bytes += ((PLC_DEFAULT_STRING_SIZE + 1) * size)
+        elif plc_datatype in PLC_8_BYTE_TYPES:
+            num_of_bytes += (8 * size)
+        elif plc_datatype in PLC_4_BYTE_TYPES:
+            num_of_bytes += (4 * size)
+        elif plc_datatype in PLC_2_BYTE_TYPES:
+            num_of_bytes += (2 * size)
+        elif plc_datatype in PLC_BYTE_TYPES:
+            num_of_bytes += (1 * size)
+        else:
+            raise RuntimeError('Datatype not found')
 
     return c_ubyte * num_of_bytes
 
 
 def list_from_bytes(byte_list, structure_def):
-    """Return a list of PLC values from a list of BYTE values read from PLC
+    """Return a list of PLC values from a list of BYTE values read from PLC.
 
     :param byte_list: list of byte values for an entire structure
     :param tuple structure_def: special tuple defining the structure and
@@ -519,6 +511,7 @@ def list_from_bytes(byte_list, structure_def):
 
             If array of structure is to be calculated use
             'list_from_bytes(structure_def * X)'
+
     :return: list of values for each variable type in order of structure
     """
     values = []
@@ -784,7 +777,7 @@ class Connection(object):
 
     def read_structure_by_name(self, data_name, structure_def):
         # type: (str, Tuple) -> List
-        """Read a structure of multiple types
+        """Read a structure of multiple types.
 
         :param string data_name: data name
         :param tuple structure_def: special tuple defining the structure and

--- a/pyads/constants.py
+++ b/pyads/constants.py
@@ -50,6 +50,33 @@ PLCTYPE_WORD = c_uint16
 PLCTYPE_LINT = c_int64
 PLCTYPE_ULINT = c_uint64
 
+# PLC Type sizes in BYTES
+PLC_BYTE_TYPES = {PLCTYPE_BOOL, PLCTYPE_BYTE, PLCTYPE_SINT, PLCTYPE_USINT}
+PLC_2_BYTE_TYPES = {PLCTYPE_WORD, PLCTYPE_INT, PLCTYPE_UINT}
+PLC_4_BYTE_TYPES = {PLCTYPE_DWORD, PLCTYPE_DINT, PLCTYPE_UDINT,
+                    PLCTYPE_REAL, PLCTYPE_TIME, PLCTYPE_TOD, PLCTYPE_DATE,
+                    PLCTYPE_DT}
+PLC_8_BYTE_TYPES = {PLCTYPE_LREAL}
+PLC_DEFAULT_STRING_SIZE = 80
+
+# Datatype unpacking values
+DATATYPE_MAP = {
+    PLCTYPE_BOOL: "<?",
+    PLCTYPE_BYTE: "<B",
+    PLCTYPE_DINT: "<i",
+    PLCTYPE_DWORD: "<I",
+    PLCTYPE_INT: "<h",
+    PLCTYPE_LREAL: "<d",
+    PLCTYPE_REAL: "<f",
+    PLCTYPE_SINT: "<b",
+    PLCTYPE_UDINT: "<I",
+    PLCTYPE_UINT: "<H",
+    PLCTYPE_USINT: "<B",
+    PLCTYPE_WORD: "<H",
+}  # type: Dict[Type, str]
+
+
+
 
 def PLCTYPE_ARR_REAL(n):
     # type: (int) -> Type[Array[c_float]]

--- a/pyads/constants.py
+++ b/pyads/constants.py
@@ -13,7 +13,7 @@ from typing import Type
 from ctypes import (
     Array,
     c_bool,
-    c_byte,
+    c_ubyte,
     c_int8,
     c_uint8,
     c_int16,
@@ -31,7 +31,7 @@ STRING_BUFFER = 1024
 
 # plc data types:
 PLCTYPE_BOOL = c_bool
-PLCTYPE_BYTE = c_byte
+PLCTYPE_BYTE = c_ubyte
 PLCTYPE_DATE = c_int32
 PLCTYPE_DINT = c_int32
 PLCTYPE_DT = c_int32

--- a/tests/test_ads.py
+++ b/tests/test_ads.py
@@ -12,6 +12,7 @@ import pyads
 from pyads import AmsAddr
 from pyads.utils import platform_is_linux
 from ctypes import c_ubyte
+from collections import OrderedDict
 import unittest
 
 
@@ -175,7 +176,177 @@ class AdsTest(unittest.TestCase):
             ('iVar1', pyads.PLCTYPE_INT, 3),
             ('bVar1', pyads.PLCTYPE_BOOL, 4),
         )
-        self.assertEqual(pyads.size_of_structure(structure_def * 5), c_ubyte*1185)
+        self.assertEqual(pyads.size_of_structure(structure_def, array_size=5), c_ubyte*1185)
+
+    def test_dict_from_bytes(self):
+        # type: () -> None
+        """Test dict_from_bytes function"""
+        # tests for known values
+        structure_def = (
+            ('rVar', pyads.PLCTYPE_LREAL, 1),
+            ('sVar', pyads.PLCTYPE_STRING, 2, 35),
+            ('rVar1', pyads.PLCTYPE_REAL, 4),
+            ('iVar', pyads.PLCTYPE_DINT, 5),
+            ('iVar1', pyads.PLCTYPE_INT, 3),
+            ('ivar2', pyads.PLCTYPE_UDINT, 6),
+            ('iVar3', pyads.PLCTYPE_UINT, 7),
+            ('iVar4', pyads.PLCTYPE_BYTE, 1),
+            ('iVar5', pyads.PLCTYPE_SINT, 1),
+            ('iVar6', pyads.PLCTYPE_USINT, 1),
+            ('bVar', pyads.PLCTYPE_BOOL, 4),
+            ('iVar7', pyads.PLCTYPE_WORD, 1),
+            ('iVar8', pyads.PLCTYPE_DWORD, 1),
+        )
+        values = OrderedDict({
+            'rVar': 1.11,
+            'sVar': ['Hello', 'World'],
+            'rVar1': [2.25, 2.25, 2.5, 2.75],
+            'iVar': [3, 4, 5, 6, 7],
+            'iVar1': [8, 9, 10],
+            'ivar2': [11, 12, 13, 14, 15, 16],
+            'iVar3': [17, 18, 19, 20, 21, 22, 23],
+            'iVar4': 24,
+            'iVar5': 25,
+            'iVar6': 26,
+            'bVar': [True, False, True, False],
+            'iVar7': 27,
+            'iVar8': 28
+        })
+        bytes_list = [195, 245, 40, 92, 143, 194, 241, 63, 72, 101, 108, 108, 111,
+                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 87, 111, 114, 108, 100, 0,
+                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 16, 64, 0, 0, 16, 64, 0,
+                      0, 32, 64, 0, 0, 48, 64, 3, 0, 0, 0, 4, 0, 0, 0, 5, 0, 0, 0,
+                      6, 0, 0, 0, 7, 0, 0, 0, 8, 0, 9, 0, 10, 0, 11, 0, 0, 0, 12,
+                      0, 0, 0, 13, 0, 0, 0, 14, 0, 0, 0, 15, 0, 0, 0, 16, 0, 0, 0,
+                      17, 0, 18, 0, 19, 0, 20, 0, 21, 0, 22, 0, 23, 0, 24, 25, 26,
+                      1, 0, 1, 0, 27, 0, 28, 0, 0, 0]
+        self.assertEqual(values,
+                         pyads.dict_from_bytes(bytes_list, structure_def))
+
+        values = OrderedDict({
+            'rVar': 780245.5678,
+            'sVar': ['TwinCat works', 'with Python using pyads'],
+            'rVar1': [65.5, 89.75, 999.5, 55555.0],
+            'iVar': [24567, -5678988, 12, -393, 0],
+            'iVar1': [-20563, 32765, -1],
+            'ivar2': [100001, 1234567890, 76, 582, 94034536, 2167],
+            'iVar3': [2167, 987, 63000, 5648, 678, 2734, 43768],
+            'iVar4': 200,
+            'iVar5': 127,
+            'iVar6': 255,
+            'bVar': [True, False, True, False],
+            'iVar7': 45367,
+            'iVar8': 256000000
+        })
+        bytes_list = [125, 174, 182, 34, 171, 207, 39, 65, 84, 119, 105, 110, 67,
+                      97, 116, 32, 119, 111, 114, 107, 115, 0, 0, 0, 0, 0, 0, 0,
+                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 119, 105,
+                      116, 104, 32, 80, 121, 116, 104, 111, 110, 32, 117, 115, 105,
+                      110, 103, 32, 112, 121, 97, 100, 115, 0, 0, 0, 0, 0, 0, 0, 0,
+                      0, 0, 0, 0, 0, 0, 0, 131, 66, 0, 128, 179, 66, 0, 224, 121,
+                      68, 0, 3, 89, 71, 247, 95, 0, 0, 116, 88, 169, 255, 12, 0, 0,
+                      0, 119, 254, 255, 255, 0, 0, 0, 0, 173, 175, 253, 127, 255,
+                      255, 161, 134, 1, 0, 210, 2, 150, 73, 76, 0, 0, 0, 70, 2, 0,
+                      0, 104, 218, 154, 5, 119, 8, 0, 0, 119, 8, 219, 3, 24, 246,
+                      16, 22, 166, 2, 174, 10, 248, 170, 200, 127, 255, 1, 0, 1, 0,
+                      55, 177, 0, 64, 66, 15]
+        self.assertEqual(values,
+                         pyads.dict_from_bytes(bytes_list, structure_def))
+
+        # test for PLC_DEFAULT_STRING_SIZE
+        structure_def = (
+            ('iVar', pyads.PLCTYPE_INT, 1),
+            ('bVar', pyads.PLCTYPE_BOOL, 1),
+            ('sVar', pyads.PLCTYPE_STRING, 1),
+            ('iVar2', pyads.PLCTYPE_DINT, 1),
+        )
+        values = OrderedDict({
+            'iVar': 32767,
+            'bVar': True,
+            'sVar': 'Testing the default string size of 80',
+            'iVar2': -25600000
+        })
+        bytes_list = [255, 127, 1, 84, 101, 115, 116, 105, 110, 103, 32, 116, 104,
+                      101, 32, 100, 101, 102, 97, 117, 108, 116, 32, 115, 116, 114,
+                      105, 110, 103, 32, 115, 105, 122, 101, 32, 111, 102, 32, 56,
+                      48, 0, 72, 137, 131, 240, 3, 6, 0, 72, 141, 131, 104, 115, 6,
+                      0, 72, 137, 131, 248, 3, 6, 0, 72, 141, 131, 104, 12, 6, 0,
+                      72, 137, 131, 0, 4, 6, 0, 72, 141, 131, 224, 114, 6, 0, 72,
+                      0, 96, 121, 254]
+        self.assertEqual(values,
+                         pyads.dict_from_bytes(bytes_list, structure_def))
+
+        # test another correct definition with array of structure
+        values_list = [
+            OrderedDict({
+                'iVar': 32767,
+                'bVar': True,
+                'sVar': 'Testing the default string size of 80',
+                'iVar2': -25600000
+            }),
+            OrderedDict({
+                'iVar': -32768,
+                'bVar': True,
+                'sVar': 'Another Test using the default string size of 80',
+                'iVar2': -25600000
+            }),
+            OrderedDict({
+                'iVar': 0,
+                'bVar': False,
+                'sVar': 'Last Test String of Array',
+                'iVar2': 1234567890
+            }),
+        ]
+        bytes_list = [255, 127, 1, 84, 101, 115, 116, 105, 110, 103, 32, 116, 104,
+                      101, 32, 100, 101, 102, 97, 117, 108, 116, 32, 115, 116, 114,
+                      105, 110, 103, 32, 115, 105, 122, 101, 32, 111, 102, 32, 56,
+                      48, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                      0, 0, 0, 0, 0, 0, 96, 121, 254, 0, 128, 1, 65, 110, 111, 116,
+                      104, 101, 114, 32, 84, 101, 115, 116, 32, 117, 115, 105, 110,
+                      103, 32, 116, 104, 101, 32, 100, 101, 102, 97, 117, 108, 116,
+                      32, 115, 116, 114, 105, 110, 103, 32, 115, 105, 122, 101, 32,
+                      111, 102, 32, 56, 48, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                      0, 96, 121, 254, 0, 0, 0, 76, 97, 115, 116, 32, 84, 101, 115,
+                      116, 32, 83, 116, 114, 105, 110, 103, 32, 111, 102, 32, 65,
+                      114, 114, 97, 121, 0, 72, 137, 131, 240, 4, 6, 0, 72, 141,
+                      131, 80, 19, 6, 0, 72, 137, 131, 248, 4, 6, 0, 72, 141, 131,
+                      168, 19, 6, 0, 72, 137, 131, 0, 5, 6, 0, 72, 141, 131, 0, 20,
+                      6, 0, 72, 137, 131, 8, 5, 6, 0, 72, 141, 131, 96, 20, 6, 210,
+                      2, 150, 73]
+        self.assertEqual(values_list,
+                         pyads.dict_from_bytes(bytes_list, structure_def, array_size=3))
+
+        # tests for incorrect definitions
+        structure_def = (
+            ('sVar', pyads.PLCTYPE_STRING, 4),
+            ('rVar', 1, 1),
+            ('iVar', pyads.PLCTYPE_DINT, 1),
+        )
+        with self.assertRaises(RuntimeError):
+            pyads.dict_from_bytes([], structure_def)
+
+        structure_def = (
+            ('sVar', pyads.PLCTYPE_STRING, 4),
+            (pyads.PLCTYPE_REAL, 1),
+            ('iVar', pyads.PLCTYPE_DINT, 1),
+        )
+        with self.assertRaises(ValueError):
+            pyads.dict_from_bytes([], structure_def)
+
+        structure_def = (
+            ('sVar', pyads.PLCTYPE_STRING, 4),
+            ('rVar', pyads.PLCTYPE_REAL, ''),
+            ('iVar', pyads.PLCTYPE_DINT, 1),
+            ('iVar1', pyads.PLCTYPE_INT, 3),
+        )
+        with self.assertRaises(TypeError):
+            pyads.dict_from_bytes([], structure_def)
+
+        # TODO tests for byte size not equal to structure def struct.error
 
 
 if __name__ == "__main__":

--- a/tests/test_ads.py
+++ b/tests/test_ads.py
@@ -154,7 +154,7 @@ class AdsTest(unittest.TestCase):
             (pyads.PLCTYPE_REAL, 1),
             ('iVar', pyads.PLCTYPE_DINT, 1),
         )
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             pyads.size_of_structure(structure_def)
 
         structure_def = (
@@ -163,7 +163,7 @@ class AdsTest(unittest.TestCase):
             ('iVar', pyads.PLCTYPE_DINT, 1),
             ('iVar1', pyads.PLCTYPE_INT, 3),
         )
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(TypeError):
             pyads.size_of_structure(structure_def)
 
         # test another correct definition with array of structure

--- a/tests/test_connection_class.py
+++ b/tests/test_connection_class.py
@@ -421,6 +421,11 @@ class AdsConnectionClassTestCase(unittest.TestCase):
         self.assertIsNone(plc.read(1, 2, pyads.PLCTYPE_INT))
         self.assertIsNone(plc.read_by_name("hello", pyads.PLCTYPE_INT))
         self.assertIsNone(
+            plc.read_structure_by_name("hello", (('', pyads.PLCTYPE_BOOL, 1),
+                                                 ('', pyads.PLCTYPE_BOOL, 1))
+            )
+        )
+        self.assertIsNone(
             plc.add_device_notification(
                 "test", pyads.NotificationAttrib(4), lambda x: x
             )


### PR DESCRIPTION
I've added a method inside the connection class the for reading structures containing multiple types, (part way to solving #82 ), you have to pre define in python your structure definition, then it essentially calculates how many bytes to request, then converts these bytes to a list of all the numbers using the defined structure. 

Let me know what you think.