### PR TITLE
additional methods for get and release PLC variable handle

### DIFF
--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -624,9 +624,11 @@ class Connection(object):
     def get_handle(self, data_name):
         # type: (str) -> int
         """Get the handle of the PLC-variable, handles obtained using this
-         method should be released using method 'release_handle'
+         method should be released using method 'release_handle'.
 
         :param string data_name: data name
+
+        :rtype: int
         :return: int: PLC-variable handle
         """
         if self._port is not None:
@@ -636,7 +638,7 @@ class Connection(object):
 
     def release_handle(self, handle):
         # type: (int) -> None
-        """ Release handle of a PLC-variable
+        """ Release handle of a PLC-variable.
 
         :param int handle: handle of PLC-variable to be released
         """
@@ -644,7 +646,8 @@ class Connection(object):
             adsReleaseHandle(self._port, self._adr, handle)
 
     def read_by_name(
-            self, data_name, plc_datatype, return_ctypes=False, handle=None):
+            self, data_name, plc_datatype, return_ctypes=False, handle=None
+    ):
         # type: (str, Type, bool, int) -> Any
         """Read data synchronous from an ADS-device from data name
 

--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -649,7 +649,7 @@ class Connection(object):
             self, data_name, plc_datatype, return_ctypes=False, handle=None
     ):
         # type: (str, Type, bool, int) -> Any
-        """Read data synchronous from an ADS-device from data name
+        """Read data synchronous from an ADS-device from data name.
 
         :param string data_name: data name,  can be empty string if handle is used
         :param int plc_datatype: type of the data given to the PLC, according
@@ -674,7 +674,7 @@ class Connection(object):
 
     def write_by_name(self, data_name, value, plc_datatype, handle=None):
         # type: (str, Any, Type, int) -> None
-        """Send data synchronous to an ADS-device from data name
+        """Send data synchronous to an ADS-device from data name.
 
         :param string data_name: data name, can be empty string if handle is used
         :param value: value to write to the storage address of the PLC

--- a/pyads/pyads_ex.py
+++ b/pyads/pyads_ex.py
@@ -638,8 +638,42 @@ def adsSyncReadReqEx2(
     return data
 
 
-def adsSyncReadByNameEx(port, address, data_name, data_type, return_ctypes=False):
-    # type: (int, AmsAddr, str, Type, bool) -> Any
+def adsGetHandle(port, address, data_name):
+    # type: (int, AmsAddr, str) -> int
+    """Get the handle of the PLC-variable
+
+    :param int port: local AMS port as returned by adsPortOpenEx()
+    :param pyads.structs.AmsAddr address: local or remote AmsAddr
+    :param data_name: string data_name: data name
+    :return: int: PLC-variable handle
+    """
+    handle = adsSyncReadWriteReqEx2(
+        port,
+        address,
+        ADSIGRP_SYM_HNDBYNAME,
+        0x0,
+        PLCTYPE_UDINT,
+        data_name,
+        PLCTYPE_STRING,
+    )
+
+    return handle
+
+
+def adsReleaseHandle(port, address, handle):
+    # type: (int, AmsAddr, int) -> None
+    """Release the handle of the PLC-variable
+
+    :param int port: local AMS port as returned by adsPortOpenEx()
+    :param pyads.structs.AmsAddr address: local or remote AmsAddr
+    :param int handle: handle of PLC-variable to be released
+    """
+    adsSyncWriteReqEx(port, address, ADSIGRP_SYM_RELEASEHND, 0, handle, PLCTYPE_UDINT)
+
+
+def adsSyncReadByNameEx(
+    port, address, data_name, data_type, return_ctypes=False, handle=None):
+    # type: (int, AmsAddr, str, Type, bool, int) -> Any
     """Read data synchronous from an ADS-device from data name.
 
     :param int port: local AMS port as returned by adsPortOpenEx()
@@ -649,34 +683,31 @@ def adsSyncReadByNameEx(port, address, data_name, data_type, return_ctypes=False
         PLCTYPE constants
     :param bool return_ctypes: return ctypes instead of python types if True
         (default: False)
+    :param int handle: PLC-variable handle (default: None)
     :rtype: data_type
     :return: value: **value**
 
     """
-    # Get the handle of the PLC-variable
-    handle = adsSyncReadWriteReqEx2(
-        port,
-        address,
-        ADSIGRP_SYM_HNDBYNAME,
-        0x0,
-        PLCTYPE_UDINT,
-        data_name,
-        PLCTYPE_STRING,
-    )
+    if handle is None:
+        no_handle = True
+        handle = adsGetHandle(port, address, data_name)
+    else:
+        no_handle = False
 
     # Read the value of a PLC-variable, via handle
     value = adsSyncReadReqEx2(
         port, address, ADSIGRP_SYM_VALBYHND, handle, data_type, return_ctypes
     )
 
-    # Release the handle of the PLC-variable
-    adsSyncWriteReqEx(port, address, ADSIGRP_SYM_RELEASEHND, 0, handle, PLCTYPE_UDINT)
+    if no_handle is True:
+        adsReleaseHandle(port, address, handle)
 
     return value
 
 
-def adsSyncWriteByNameEx(port, address, data_name, value, data_type):
-    # type: (int, AmsAddr, str, Any, Type) -> None
+def adsSyncWriteByNameEx(
+    port, address, data_name, value, data_type, handle=None):
+    # type: (int, AmsAddr, str, Any, Type, int) -> None
     """Send data synchronous to an ADS-device from data name.
 
     :param int port: local AMS port as returned by adsPortOpenEx()
@@ -685,29 +716,23 @@ def adsSyncWriteByNameEx(port, address, data_name, value, data_type):
     :param value: value to write to the storage address of the PLC
     :param Type data_type: type of the data given to the PLC,
         according to PLCTYPE constants
-
+    :param int handle: PLC-variable handle (default: None)
     """
-    # Get the handle of the PLC-variable
-    handle = adsSyncReadWriteReqEx2(
-        port,
-        address,
-        ADSIGRP_SYM_HNDBYNAME,
-        0x0,
-        PLCTYPE_UDINT,
-        data_name,
-        PLCTYPE_STRING,
-    )
+    if handle is None:
+        no_handle = True
+        handle = adsGetHandle(port, address, data_name)
+    else:
+        no_handle = False
 
     # Write the value of a PLC-variable, via handle
     adsSyncWriteReqEx(port, address, ADSIGRP_SYM_VALBYHND, handle, value, data_type)
 
-    # Release the handle of the PLC-variable
-    adsSyncWriteReqEx(port, address, ADSIGRP_SYM_RELEASEHND, 0, handle, PLCTYPE_UDINT)
+    if no_handle is True:
+        adsReleaseHandle(port, address, handle)
 
 
 def adsSyncAddDeviceNotificationReqEx(
-    port, adr, data_name, pNoteAttrib, callback, user_handle=None
-):
+    port, adr, data_name, pNoteAttrib, callback, user_handle=None):
     # type: (int, AmsAddr, str, NotificationAttrib, Callable, int) -> Tuple[int, int]
     """Add a device notification.
 

--- a/pyads/pyads_ex.py
+++ b/pyads/pyads_ex.py
@@ -640,12 +640,13 @@ def adsSyncReadReqEx2(
 
 def adsGetHandle(port, address, data_name):
     # type: (int, AmsAddr, str) -> int
-    """Get the handle of the PLC-variable
+    """Get the handle of the PLC-variable.
 
     :param int port: local AMS port as returned by adsPortOpenEx()
     :param pyads.structs.AmsAddr address: local or remote AmsAddr
-    :param data_name: string data_name: data name
-    :return: int: PLC-variable handle
+    :param string data_name: data name
+    :rtype: int
+    :return: handle: PLC-variable handle
     """
     handle = adsSyncReadWriteReqEx2(
         port,
@@ -662,7 +663,7 @@ def adsGetHandle(port, address, data_name):
 
 def adsReleaseHandle(port, address, handle):
     # type: (int, AmsAddr, int) -> None
-    """Release the handle of the PLC-variable
+    """Release the handle of the PLC-variable.
 
     :param int port: local AMS port as returned by adsPortOpenEx()
     :param pyads.structs.AmsAddr address: local or remote AmsAddr
@@ -672,7 +673,8 @@ def adsReleaseHandle(port, address, handle):
 
 
 def adsSyncReadByNameEx(
-    port, address, data_name, data_type, return_ctypes=False, handle=None):
+    port, address, data_name, data_type, return_ctypes=False, handle=None
+):
     # type: (int, AmsAddr, str, Type, bool, int) -> Any
     """Read data synchronous from an ADS-device from data name.
 
@@ -706,7 +708,8 @@ def adsSyncReadByNameEx(
 
 
 def adsSyncWriteByNameEx(
-    port, address, data_name, value, data_type, handle=None):
+        port, address, data_name, value, data_type, handle=None
+):
     # type: (int, AmsAddr, str, Any, Type, int) -> None
     """Send data synchronous to an ADS-device from data name.
 
@@ -732,7 +735,8 @@ def adsSyncWriteByNameEx(
 
 
 def adsSyncAddDeviceNotificationReqEx(
-    port, adr, data_name, pNoteAttrib, callback, user_handle=None):
+    port, adr, data_name, pNoteAttrib, callback, user_handle=None
+):
     # type: (int, AmsAddr, str, NotificationAttrib, Callable, int) -> Tuple[int, int]
     """Add a device notification.
 


### PR DESCRIPTION
I've added in additional methods into the Connection class to get and release PLC variable handles. Additionally I have then modified read and write by name methods and functions to allow the user to pass this handle in as an optional argument.  This gives the user to option to handle getting and releasing of handles themselves and in doing so **speeds the reading and writing process up by up to 3x** when using read_by_name and write_by_name.

As this is an optional argument it should not affect user's existing code or those that do not wish to handle handles themselves, but those that do can get a significant speed advantage. 

