### PR TITLE
changed BYTE type to ctypes c_ubyte

### DIFF
--- a/pyads/constants.py
+++ b/pyads/constants.py
@@ -13,7 +13,7 @@ from typing import Type
 from ctypes import (
     Array,
     c_bool,
-    c_byte,
+    c_ubyte,
     c_int8,
     c_uint8,
     c_int16,
@@ -31,7 +31,7 @@ STRING_BUFFER = 1024
 
 # plc data types:
 PLCTYPE_BOOL = c_bool
-PLCTYPE_BYTE = c_byte
+PLCTYPE_BYTE = c_ubyte
 PLCTYPE_DATE = c_int32
 PLCTYPE_DINT = c_int32
 PLCTYPE_DT = c_int32


### PR DESCRIPTION
This fixes #85 , writing was not an issue using c_byte but when reading with c_byte python unpacks this wrong (e.g. 200 reads as -56). The PLC BYTE type is unsigned therefore using c_ubyte is correct.