### PR TITLE
bug fix for setting up remote route from linux

### DIFF
--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -16,6 +16,7 @@ Open a port and create an AmsAddr object for the remote machine.
 >>> import pyads
 >>> pyads.open_port()
 32828
+>>> pyads.set_local_address('1.2.3.4.1.1')
 ```
 Add a route to the remote machine (Linux only - Windows routes must be
 added in the TwinCat Router UI).
@@ -23,8 +24,13 @@ added in the TwinCat Router UI).
 ```python
 >>> pyads.add_route("192.168.0.100.1.1", "192.168.0.100")
 ```
-Another option is to use the Connection class.
+A better option is to use the Connection class.
+
 ```python
+>>> import pyads
+>>> pyads.open_port()
+>>> pyads.set_local_address('1.2.3.4.1.1')
+>>> pyads.close_port()
 >>> remote_ip = '192.168.0.100'
 >>> remote_ads = '5.12.82.20.1.1'
 >>> with pyads.Connection(remote_ads, pyads.PORT_SPS1, remote_ip) as plc:
@@ -37,20 +43,20 @@ the routing table of the remote machine.
 to `get_local_address()` will function properly.**
 
 ### Adding routes to a PLC on Linux
-Beckhoff PLCs require that a route be added to the routing table of the PLC. Normally this is handled in the TwinCAT router on Windows, but on Linux there is no such option.
+Beckhoff PLCs require that a route be added to the routing table of the PLC. On Windows this is handled in the TwinCAT router, but on Linux there is no such option.
 This only needs to be done once when initially setting up a connection to a remote PLC.
 
 Adding a route to a remote PLC to allow connections to a PC with the Hostname "MyPC"
-``` python
+
+```python
 >>> import pyads
 >>> SENDER_AMS = '1.2.3.4.1.1'
 >>> PLC_IP = '192.168.0.100'
->>> USERNAME = 'user'
->>> PASSWORD = 'password'
->>> ROUTE_NAME = 'RouteToMyPC'
->>> HOSTNAME = 'MyPC'
+>>> PLC_USERNAME = 'plc_username'
+>>> PLC_PASSWORD = 'plc_password'
+>>> HOSTNAME = 'MyPC'  # or IP address of sender PC
 >>> PLC_AMS_ID = '11.22.33.44.1.1'
->>> pyads.add_route_to_plc(SENDER_AMS, HOSTNAME, PLC_IP, USERNAME, PASSWORD, route_name=ROUTE_NAME)
+>>> pyads.add_route_to_plc(SENDER_AMS, HOSTNAME, PLC_IP, PLC_USERNAME, PLC_PASSWORD)
 ```
 
 ### Creating routes on Windows

--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -358,20 +358,15 @@ def add_route_to_plc(
     ip_address,
     username,
     password,
-    route_name=None,
-    added_net_id=None,
 ):
-    # type: (AmsAddr, str, str, str, str, str, AmsAddr) -> None
+    # type: (str, str, str, str, str) -> bool
     """Embed a new route in the PLC.
 
-    :param pyads.structs.SAmsNetId sending_net_id: sending net id
-    :param str adding_host_name: host name (or IP) of the PC being added, defaults to hostname of this PC
-    :param str ip_address: ip address of the routing endpoint
+    :param str: sending net id
+    :param str adding_host_name: host name (or IP) of the PC being added
+    :param str ip_address: ip address of the PLC
     :param str username: username for PLC
     :param str password: password for PLC
-    :param str route_name: PLC side name for route, defaults to adding_host_name or the current hostename of this PC
-    :param pyads.structs.SAmsNetId added_net_id: net id that is being added to the PLC, defaults to sending_net_id
-
     """
     return adsAddRouteToPLC(
         sending_net_id,
@@ -379,8 +374,6 @@ def add_route_to_plc(
         ip_address,
         username,
         password,
-        route_name=route_name,
-        added_net_id=added_net_id,
     )
 
 

--- a/tests/test_plc_route.py
+++ b/tests/test_plc_route.py
@@ -13,8 +13,6 @@ class PLCRouteTestCase(unittest.TestCase):
     PLC_IP = "127.0.0.1"
     USERNAME = "user"
     PASSWORD = "password"
-    ROUTE_NAME = "Route"
-    ADDING_AMS_ID = "5.6.7.8.1.1"
     HOSTNAME = "Host"
     PLC_AMS_ID = "11.22.33.44.1.1"
 
@@ -106,7 +104,7 @@ class PLCRouteTestCase(unittest.TestCase):
                 len_sending_host, len(self.HOSTNAME) + 1
             )  # +1 for the null terminator
             self.assertEqual(hostname, self.HOSTNAME + "\0")
-            self.assertEqual(adding_ams_id, self.ADDING_AMS_ID)
+            self.assertEqual(adding_ams_id, self.SENDER_AMS)
             self.assertEqual(
                 len_username, len(self.USERNAME) + 1
             )  # +1 for the null terminator
@@ -118,9 +116,9 @@ class PLCRouteTestCase(unittest.TestCase):
             # self.assertEqual(password, self.PASSWORD + '\0')
 
             self.assertEqual(
-                len_route_name, len(self.ROUTE_NAME) + 1
+                len_route_name, len(self.HOSTNAME) + 1
             )  # +1 for the null terminator
-            self.assertEqual(route_name, self.ROUTE_NAME + "\0")
+            self.assertEqual(route_name, self.HOSTNAME + "\0")
 
             if password == self.PASSWORD + "\0":
                 password_correct = True
@@ -165,8 +163,6 @@ class PLCRouteTestCase(unittest.TestCase):
                     self.PLC_IP,
                     self.USERNAME,
                     self.PASSWORD,
-                    route_name=self.ROUTE_NAME,
-                    added_net_id=self.ADDING_AMS_ID,
                 )
             except:
                 result = None
@@ -188,8 +184,6 @@ class PLCRouteTestCase(unittest.TestCase):
                     self.PLC_IP,
                     self.USERNAME,
                     "Incorrect Password",
-                    route_name=self.ROUTE_NAME,
-                    added_net_id=self.ADDING_AMS_ID,
                 )
             except:
                 result = None


### PR DESCRIPTION
alternative solution from #97  for #66 (and deriative)

This or #97 could be implemented as a quick hotfix for the setting up route from linux issue. 

This one just removes the ability to change the route_name, so is essentially like not using the optional inputs of the function. Breaks backward compaibilty but this is aimed a being a hot_fix.

@Adrian-at-CrimsonAuzre what do you think?