### PR TITLE
Require typing only for Python < 3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -160,7 +160,7 @@ setup(
     packages=["pyads", "pyads.testserver_ex"],
     package_data={'pyads': ['adslib.so']},
     requires=[],
-    install_requires=['typing'],
+    install_requires=['typing;python_version<"3.5"'],
     provides=['pyads'],
     url='https://github.com/MrLeeh/pyads',
     classifiers=[


### PR DESCRIPTION
In newer it's included.