### PR TITLE
Add Python 3.8 on Travis CI test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
 
 # command to install dependencies
 install:

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py35, py36, py37
+envlist = py27, py35, py36, py37, py38
 
 [testenv]
 commands = discover


### PR DESCRIPTION
Python 3.8 was released on October 14th, 2019.