### PR TITLE
Store notification callbacks per AmsAddr

### DIFF
--- a/pyads/pyads_ex.py
+++ b/pyads/pyads_ex.py
@@ -827,7 +827,7 @@ def adsSyncAddDeviceNotificationReqEx(
 
     if err_code:
         raise ADSError(err_code)
-    callback_store[pNotification.value] = c_callback
+    callback_store[(adr, pNotification.value)] = c_callback
     return (pNotification.value, hnl)
 
 
@@ -846,7 +846,7 @@ def adsSyncDelDeviceNotificationReqEx(port, adr, notification_handle, user_handl
     pAmsAddr = ctypes.pointer(adr.amsAddrStruct())
     nHNotification = ctypes.c_ulong(notification_handle)
     err_code = adsSyncDelDeviceNotificationReqFct(port, pAmsAddr, nHNotification)
-    callback_store.pop(notification_handle, None)
+    del callback_store[(adr, notification_handle)]
     if err_code:
         raise ADSError(err_code)
 


### PR DESCRIPTION
Notification handles are separate per AMS server and port, so storing
the ctypes callback handle in the callback handle map requires indexing
with both of these information. Otherwise, handles will get overwritten
and the program will crash when trying to access the garbage-collected
handles.

Fix for #80 

I just went ahead with this minimally-invasive solution due to the lack of feedback. It would be nice to get this in at least to fix the crashes as they occur at the moment.