### PR TITLE
Add getters/setters for connection netid and port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * [#111](https://github.com/stlehmann/pyads/pull/111) test cases for notification decorators
 * [#113](https://github.com/stlehmann/pyads/pull/113) Add option not to check for data size
 * [#118](https://github.com/stlehmann/pyads/pull/118) Add support for arrays in notification decorator
+* [#112](https://github.com/stlehmann/pyads/pull/112) Add getters/setters for connection netid and port 
 
 ### Changed
 * [#128](https://github.com/stlehmann/pyads/pull/128) Deprecation warning for older non-class functions. In

--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -633,6 +633,8 @@ class Connection(object):
     @ams_netid.setter
     def ams_netid(self, netid):
         # type: (str) -> None
+        if self._open:
+            raise AttributeError("Setting netid is not allowed while connection is open.")
         self._adr.netid = netid
 
     @property
@@ -643,6 +645,8 @@ class Connection(object):
     @ams_port.setter
     def ams_port(self, port):
         # type: (int) -> None
+        if self._open:
+            raise AttributeError("Setting port is not allowed while connection is open.")
         self._adr.port = port
 
     def __enter__(self):

--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -625,6 +625,26 @@ class Connection(object):
         self._open = False
         self._notifications = {}  # type: Dict[int, str]
 
+    @property
+    def ams_netid(self):
+        # type: () -> str
+        return self._adr.netid
+
+    @ams_netid.setter
+    def ams_netid(self, netid):
+        # type: (str) -> None
+        self._adr.netid = netid
+
+    @property
+    def ams_port(self):
+        # type: () -> int
+        return self._adr.port
+
+    @ams_port.setter
+    def ams_port(self, port):
+        # type: (int) -> None
+        self._adr.port = port
+
     def __enter__(self):
         # type: () -> Connection
         """Open on entering with-block."""

--- a/tests/test_connection_class.py
+++ b/tests/test_connection_class.py
@@ -105,6 +105,14 @@ class AdsConnectionClassTestCase(unittest.TestCase):
         self.plc.ams_port = 1
         self.assertEqual(self.plc.ams_port, 1)
 
+        # test for AttributeError when trying to set netid or port
+        # for an open connection
+        self.plc._open = True
+        with self.assertRaises(AttributeError):
+            self.plc.ams_netid = "1.1.1.1.1.2"
+        with self.assertRaises(AttributeError):
+            self.plc.ams_port = 2
+
     def test_read_device_info(self):
         with self.plc:
             name, version = self.plc.read_device_info()

--- a/tests/test_connection_class.py
+++ b/tests/test_connection_class.py
@@ -95,6 +95,16 @@ class AdsConnectionClassTestCase(unittest.TestCase):
         # connection should now be closed
         self.assertFalse(self.plc.is_open)
 
+    def test_netid_port(self):
+        self.assertEqual(self.plc.ams_netid, TEST_SERVER_AMS_NET_ID)
+        self.assertEqual(self.plc.ams_port, TEST_SERVER_AMS_PORT)
+        with self.assertRaises(ValueError):
+            self.plc.ams_netid = "1.1.1.1.1.1.1"
+        self.plc.ams_netid = "1.1.1.1.1.1"
+        self.assertEqual(self.plc.ams_netid, "1.1.1.1.1.1")
+        self.plc.ams_port = 1
+        self.assertEqual(self.plc.ams_port, 1)
+
     def test_read_device_info(self):
         with self.plc:
             name, version = self.plc.read_device_info()


### PR DESCRIPTION
I find it useful to be able to query what netid and port a connection is using. Additionally, I need to be able to create a connection object when I don't know the target netid yet. The connection does not actually use the netid until `open()` is called (the ADS functions themselves are not even limited to interacting with one netid). So this commit also adds the possibility to set/change the netid later on.