### PR TITLE
Add LICENSE and README.rst to the package manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
 include adslib/*
+include LICENSE
+include README.rst


### PR DESCRIPTION
For packaging pyads on conda-forge, it would be a good idea to include both these files. Then you won't have to include LICENSE inside of the recipe (https://github.com/conda-forge/staged-recipes/pull/10809).