### PR TITLE
Allow read_write with NULL read/write data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Added
+* [#130](https://github.com/stlehmann/pyads/pull/130) Allow read_write with NULL read/write data
+
 ## 3.2.0
 
 ### Added

--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -778,19 +778,18 @@ class Connection(object):
         return_ctypes=False,
         check_length=True,
     ):
-        # type: (int, int, Type, Any, Type, bool, bool) -> Any
+        # type: (int, int, Optional[Type], Any, Optional[Type], bool, bool) -> Any
         """Read and write data synchronous from/to an ADS-device.
 
         :param int index_group: PLC storage area, according to the INDEXGROUP
             constants
         :param int index_offset: PLC storage address
-        :param int plc_read_datatype: type of the data given to the PLC to
-            respond to, according to PLCTYPE constants
+        :param Type plc_read_datatype: type of the data given to the PLC to respond to,
+            according to PLCTYPE constants, or None to not read anything
         :param value: value to write to the storage address of the PLC
-        :param plc_write_datatype: type of the data given to the PLC,
-            according to PLCTYPE constants
-            :rtype: PLCTYPE
-    :param bool return_ctypes: return ctypes instead of python types if True
+        :param Type plc_write_datatype: type of the data given to the PLC, according to
+            PLCTYPE constants, or None to not write anything
+        :param bool return_ctypes: return ctypes instead of python types if True
         (default: False)
         :param bool check_length: check whether the amount of bytes read matches the size
             of the read data type (default: True)

--- a/pyads/pyads_ex.py
+++ b/pyads/pyads_ex.py
@@ -521,7 +521,7 @@ def adsSyncReadWriteReqEx2(
     return_ctypes=False,
     check_length=True,
 ):
-    # type: (int, AmsAddr, int, int, Type, Any, Type, bool, bool) -> Any
+    # type: (int, AmsAddr, int, int, Optional[Type], Any, Optional[Type], bool, bool) -> Any
     """Read and write data synchronous from/to an ADS-device.
 
     :param int port: local AMS port as returned by adsPortOpenEx()
@@ -530,10 +530,10 @@ def adsSyncReadWriteReqEx2(
         constants
     :param int index_offset: PLC storage address
     :param Type read_data_type: type of the data given to the PLC to respond to,
-        according to PLCTYPE constants
+        according to PLCTYPE constants, or None to not read anything
     :param value: value to write to the storage address of the PLC
     :param Type write_data_type: type of the data given to the PLC, according to
-        PLCTYPE constants
+        PLCTYPE constants, or None to not write anything
     :param bool return_ctypes: return ctypes instead of python types if True
         (default: False)
     :param bool check_length: check whether the amount of bytes read matches the size
@@ -548,18 +548,26 @@ def adsSyncReadWriteReqEx2(
     index_group_c = ctypes.c_ulong(index_group)
     index_offset_c = ctypes.c_ulong(index_offset)
 
-    if read_data_type == PLCTYPE_STRING:
-        read_data = (STRING_BUFFER * PLCTYPE_STRING)()
+    if read_data_type is None:
+        read_data = None
+        read_data_pointer = None
+        read_length = ctypes.c_ulong(0)
     else:
-        read_data = read_data_type()
+        if read_data_type == PLCTYPE_STRING:
+            read_data = (STRING_BUFFER * PLCTYPE_STRING)()
+        else:
+            read_data = read_data_type()
 
-    read_data_pointer = ctypes.pointer(read_data)
-    read_length = ctypes.c_ulong(ctypes.sizeof(read_data))
+        read_data_pointer = ctypes.pointer(read_data)
+        read_length = ctypes.c_ulong(ctypes.sizeof(read_data))
 
     bytes_read = ctypes.c_ulong()
     bytes_read_pointer = ctypes.pointer(bytes_read)
 
-    if write_data_type == PLCTYPE_STRING:
+    if write_data_type is None:
+        write_data_pointer = None
+        write_length = ctypes.c_ulong(0)
+    elif write_data_type == PLCTYPE_STRING:
         # Get pointer to string
         write_data_pointer = ctypes.c_char_p(
             value.encode("utf-8")
@@ -613,7 +621,7 @@ def adsSyncReadWriteReqEx2(
     if type(read_data_type).__name__ == "PyCArrayType":
         return [i for i in read_data]
 
-    if hasattr(read_data, "value"):
+    if read_data is not None and hasattr(read_data, "value"):
         return read_data.value
 
     return read_data

--- a/pyads/testserver.py
+++ b/pyads/testserver.py
@@ -448,8 +448,14 @@ class BasicHandler(AbstractHandler):
             logger.info("Command received: READ_WRITE")
             # Parse requested data length
             response_length = struct.unpack("<I", request.ams_header.data[8:12])[0]
-            # Create response of repeated 0x0F with a null terminator for strings
-            response_value = (("\x0F" * (response_length - 1)) + "\x00").encode("utf-8")
+            if response_length > 0:
+                # Create response of repeated 0x0F with a null terminator for strings
+                response_value = (("\x0F" * (response_length - 1)) + "\x00").encode(
+                    "utf-8"
+                )
+            else:
+                response_value = b""
+
             response_content = struct.pack("<I", len(response_value)) + response_value
 
         else:


### PR DESCRIPTION
This is useful e.g. for a generic RPC interface where some functions
to be called over ADS do not have any parameter or return value (`void(void)` in C terms).

This is the last PR that I still had in the pipeline :-)