### PR TITLE
Add FILETIME passthrough to notification decorator

### DIFF
--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -1069,7 +1069,7 @@ class Connection(object):
 
         :param plc_datatype: The PLC datatype that needs to be converted. This can
         be any basic PLC datatype or a `ctypes.Structure`.
-        :param timestamp_as_filetim: Whether the notification timestamp should be returned
+        :param timestamp_as_filetime: Whether the notification timestamp should be returned
         as `datetime.datetime` (False) or Windows `FILETIME` as originally transmitted
         via ADS (True). Be aware that the precision of `datetime.datetime` is limited to
         microseconds, while FILETIME allows for 100 ns. This may be relevant when using

--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -1057,8 +1057,8 @@ class Connection(object):
         if self._port is not None:
             adsSyncSetTimeoutEx(self._port, ms)
 
-    def notification(self, plc_datatype=None):
-        # type: (Optional[Type[Any]]) -> Callable
+    def notification(self, plc_datatype=None, timestamp_as_filetime=False):
+        # type: (Optional[Type], bool) -> Callable
         """Decorate a callback function.
 
         **Decorator**.
@@ -1069,6 +1069,11 @@ class Connection(object):
 
         :param plc_datatype: The PLC datatype that needs to be converted. This can
         be any basic PLC datatype or a `ctypes.Structure`.
+        :param timestamp_as_filetim: Whether the notification timestamp should be returned
+        as `datetime.datetime` (False) or Windows `FILETIME` as originally transmitted
+        via ADS (True). Be aware that the precision of `datetime.datetime` is limited to
+        microseconds, while FILETIME allows for 100 ns. This may be relevant when using
+        task cycle times such as 62.5 µs. Default: False.
 
         The callback functions need to be of the following type:
 
@@ -1102,7 +1107,7 @@ class Connection(object):
         """
 
         def notification_decorator(func):
-            # type: (Callable[[int, str, datetime, Any], None]) -> Callable[[Any, str], None] # noqa: E501
+            # type: (Union[Callable[[int, str, datetime, Any], None], Callable[[int, str, int, Any], None]]) -> Callable[[Any, str], None] # noqa: E501
 
             def func_wrapper(notification, data_name):
                 # type: (Any, str) -> None
@@ -1137,9 +1142,12 @@ class Connection(object):
                         0
                     ]
 
-                dt = filetime_to_dt(contents.nTimeStamp)
+                if timestamp_as_filetime:
+                    timestamp = contents.nTimeStamp
+                else:
+                    timestamp = filetime_to_dt(contents.nTimeStamp)
 
-                return func(contents.hNotification, data_name, dt, value)
+                return func(contents.hNotification, data_name, timestamp, value)
 
             return func_wrapper
 

--- a/tests/test_connection_class.py
+++ b/tests/test_connection_class.py
@@ -546,6 +546,20 @@ class AdsConnectionClassTestCase(unittest.TestCase):
         notification.data = 5
         callback(pointer(notification), "TestName")
 
+    def test_notification_decorator_filetime(self):
+        # type: () -> None
+        """Test passthrough of FILETIME value by notification decorator"""
+
+        @self.plc.notification(timestamp_as_filetime=True)
+        def callback(handle, name, timestamp, value):
+            self.assertEqual(timestamp, 132223104000000000)
+
+        notification = structs.SAdsNotificationHeader()
+        notification.nTimeStamp = 132223104000000000
+        notification.cbSampleSize = 1
+        notification.data = 5
+        callback(pointer(notification), "TestName")
+
     def test_notification_decorator_string(self):
         # type: () -> None
         """Test decoding of STRING value by notification decorator"""


### PR DESCRIPTION
datetime has inferior precision when compared to the original FILETIME
transmitted by ADS. Add the ability to have the FILETIME value passed
through in order to support the full resolution optionally if the
caller requests it.

Closes #116.