### PR TITLE
Fix documentation and test issues with DeviceNotifications

### DIFF
--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -286,7 +286,7 @@ can be seen here:
 >>> from ctypes import sizeof
 >>>
 >>> # define the callback which extracts the value of the variable
->>> def callback(addr, notification, user_handle):
+>>> def callback(notification, data):
 >>>     contents = notification.contents
 >>>     var = next(map(int, bytearray(contents.data)[0:contents.cbSampleSize]))
 >>>
@@ -325,15 +325,15 @@ For more information about the NotificationAttrib settings have a look at
 **Here are some examples of callbacks for other datatypes:**
 
 ```python
-def callbackBool(adr, notification, user):
+def callbackBool(notification, data):
         contents = notification.contents
         var = map(bool, bytearray(contents.data)[0:contents.cbSampleSize])[0]
 
-def callbackInt(adr, notification, user):
+def callbackInt(notification, data):
         contents = notification.contents
         var = map(int, bytearray(contents.data)[0:contents.cbSampleSize])[0]
 
-def callbackString(adr, notification, user):
+def callbackString(notification, data):
         dest = (c_ubyte * contents.cbSampleSize)()
         memmove(addressof(dest), addressof(contents.data), contents.cbSampleSize)
         # Remove nullbytes

--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -430,8 +430,7 @@ def add_device_notification(adr, data, attr, callback, user_handle=None):
     :param Union[str, Tuple[int, int] data: PLC storage address as string or Tuple with index group and offset
     :param pyads.structs.NotificationAttrib attr: object that contains
         all the attributes for the definition of a notification
-    :param callback: callback function that gets executed on in the event
-        of a notification
+    :param callback: callback function that gets executed in the event of a notification
 
     :rtype: (int, int)
     :returns: notification handle, user handle
@@ -980,8 +979,7 @@ class Connection(object):
         :param Union[str, Tuple[int, int] data: PLC storage address as string or Tuple with index group and offset
         :param pyads.structs.NotificationAttrib attr: object that contains
             all the attributes for the definition of a notification
-        :param callback: callback function that gets executed on in the event
-            of a notification
+        :param callback: callback function that gets executed in the event of a notification
 
         :rtype: (int, int)
         :returns: notification handle, user handle
@@ -999,7 +997,7 @@ class Connection(object):
             >>> plc = pyads.Connection('127.0.0.1.1.1', 851)
             >>>
             >>> # Create callback function that prints the value
-            >>> def mycallback(adr, notification, user):
+            >>> def mycallback(notification, data):
             >>>     contents = notification.contents
             >>>     value = next(
             >>>         map(int,
@@ -1011,11 +1009,10 @@ class Connection(object):
             >>>     # Add notification with default settings
             >>>     attr = pyads.NotificationAttrib(size_of(pyads.PLCTYPE_INT))
             >>>
-            >>>     hnotification, huser = plc.add_device_notification(
-            >>>         adr, attr, mycallback)
+            >>>     handles = plc.add_device_notification("GVL.myvalue", attr, mycallback)
             >>>
             >>>     # Remove notification
-            >>>     plc.del_device_notification(hnotification, huser)
+            >>>     plc.del_device_notification(handles)
 
         """
         if self._port is not None:

--- a/tests/test_connection_class.py
+++ b/tests/test_connection_class.py
@@ -538,7 +538,7 @@ class AdsConnectionClassTestCase(unittest.TestCase):
             self.plc.release_handle(handle)
 
     def test_device_notification(self):
-        def callback(adr, notification, user):
+        def callback(notification, data):
             pass
 
         handle_name = "test"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -478,7 +478,7 @@ class AdsApiTestCase(TestCase):
         self.assert_command_id(requests[2], constants.ADSCOMMAND_WRITE)
 
     def test_device_notification_by_name(self):
-        def callback(adr, notification, user):
+        def callback(notification, data):
             pass
 
         handle_name = "TestHandle"
@@ -500,7 +500,7 @@ class AdsApiTestCase(TestCase):
         self.assert_command_id(requests[2], constants.ADSCOMMAND_DELDEVICENOTE)
 
     def test_device_notification_by_tuple(self):
-        def callback(adr, notification, user):
+        def callback(notification, data):
             pass
 
         n_index_group = 1
@@ -527,7 +527,7 @@ class AdsApiTestCase(TestCase):
         self.assert_command_id(requests[1], constants.ADSCOMMAND_DELDEVICENOTE)
 
     def test_device_notification_data_error(self):
-        def callback(adr, notification, user):
+        def callback(notification, data):
             pass
 
         attr = NotificationAttrib(length=4)


### PR DESCRIPTION
This PR fixes issues resulting from #56 which introduced a wrapper function that allows to pass the name of the variable as an argument to the callback function. This also resulted in a change of the expected function parameters.

Originally  a callback function should be defined like this:

```
def callback(addr, notification, user_handle):
    pass
```

This changed to this:

```
def callback(notification, data):
    pass
```
Where data is the variable name or address tuple. This change went unnoticed and was not recogniced within the tests. However it became obvious as on Windows there was an error due to the differing function layout (#132). 

This PR changes the documentation and the test cases to fit the new notification callback definition.