### PR TITLE
Add notification_parser method to Connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * [#111](https://github.com/stlehmann/pyads/pull/111) test cases for notification decorators
 * [#113](https://github.com/stlehmann/pyads/pull/113) Add option not to check for data size
 * [#118](https://github.com/stlehmann/pyads/pull/118) Add support for arrays in notification decorator
-* [#112](https://github.com/stlehmann/pyads/pull/112) Add getters/setters for connection netid and port
+* [#112](https://github.com/stlehmann/pyads/pull/112) Add getters/setters for connection netid and port 
 
 ### Changed
 * [#128](https://github.com/stlehmann/pyads/pull/128) Deprecation warning for older non-class functions. In
@@ -52,12 +52,12 @@ future versions only methods of the Connection class are supported.
 * [#125](https://github.com/stlehmann/pyads/pull/125) Add notifications by address. The `data_name
 ` parameter changed to `data` as now not only strings can be passed but also a tuple with index group and offset.
 * [#123](https://github.com/stlehmann/pyads/pull/123) Add ULINT data type
-* [#106](https://github.com/stlehmann/pyads/pull/106) Store notification callbacks per AmsAddr
+* [#106](https://github.com/stlehmann/pyads/pull/106) Store notification callbacks per AmsAddr 
 
 ### Removed
 
 ## 3.1.2
-* new function read_structure_by_name to read a structure with multiple
+* new function read_structure_by_name to read a structure with multiple 
 datatypes from the plc (issue #82, many thanks to @chrisbeardy)
 * simplify pyads.add_route, now the ams address can be supplied by a string
 instead of an AmsAddr object

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 * [#141](https://github.com/stlehmann/pyads/issues/141) Add ULINT support to read_structure_by_name
+* [#143](https://github.com/stlehmann/pyads/issues/143) Add parse_notification method to Connection
 
 ### Changed
 * [#140](https://github.com/stlehmann/pyads/pull/140) Fix lineendings to LF in the repository
@@ -33,7 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * [#111](https://github.com/stlehmann/pyads/pull/111) test cases for notification decorators
 * [#113](https://github.com/stlehmann/pyads/pull/113) Add option not to check for data size
 * [#118](https://github.com/stlehmann/pyads/pull/118) Add support for arrays in notification decorator
-* [#112](https://github.com/stlehmann/pyads/pull/112) Add getters/setters for connection netid and port 
+* [#112](https://github.com/stlehmann/pyads/pull/112) Add getters/setters for connection netid and port
 
 ### Changed
 * [#128](https://github.com/stlehmann/pyads/pull/128) Deprecation warning for older non-class functions. In
@@ -51,12 +52,12 @@ future versions only methods of the Connection class are supported.
 * [#125](https://github.com/stlehmann/pyads/pull/125) Add notifications by address. The `data_name
 ` parameter changed to `data` as now not only strings can be passed but also a tuple with index group and offset.
 * [#123](https://github.com/stlehmann/pyads/pull/123) Add ULINT data type
-* [#106](https://github.com/stlehmann/pyads/pull/106) Store notification callbacks per AmsAddr 
+* [#106](https://github.com/stlehmann/pyads/pull/106) Store notification callbacks per AmsAddr
 
 ### Removed
 
 ## 3.1.2
-* new function read_structure_by_name to read a structure with multiple 
+* new function read_structure_by_name to read a structure with multiple
 datatypes from the plc (issue #82, many thanks to @chrisbeardy)
 * simplify pyads.add_route, now the ams address can be supplied by a string
 instead of an AmsAddr object

--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -1149,7 +1149,7 @@ class Connection(object):
         >>> # Create callback function that prints the value
         >>> def mycallback(notification, data):
         >>>     data_type = tag[data]
-        >>>     handle, timestamp, value = plc.notification_parser(notification, data_type)
+        >>>     handle, timestamp, value = plc.parse_notification(notification, data_type)
         >>>     print(value)
         >>>
         >>> with plc:

--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -633,7 +633,9 @@ class Connection(object):
     def ams_netid(self, netid):
         # type: (str) -> None
         if self._open:
-            raise AttributeError("Setting netid is not allowed while connection is open.")
+            raise AttributeError(
+                "Setting netid is not allowed while connection is open."
+            )
         self._adr.netid = netid
 
     @property
@@ -645,7 +647,9 @@ class Connection(object):
     def ams_port(self, port):
         # type: (int) -> None
         if self._open:
-            raise AttributeError("Setting port is not allowed while connection is open.")
+            raise AttributeError(
+                "Setting port is not allowed while connection is open."
+            )
         self._adr.port = port
 
     def __enter__(self):
@@ -1107,44 +1111,92 @@ class Connection(object):
 
             def func_wrapper(notification, data_name):
                 # type: (Any, str) -> None
-                contents = notification.contents
-                data_size = contents.cbSampleSize
-                # Get dynamically sized data array
-                data = (c_ubyte * data_size).from_address(
-                    addressof(contents) + SAdsNotificationHeader.data.offset
+                hNotification, timestamp, value = self.notification_parser(
+                    notification, plc_datatype, timestamp_as_filetime
                 )
-
-                if plc_datatype == PLCTYPE_STRING:
-                    # read only until null-termination character
-                    value = bytearray(data).split(b"\0", 1)[0].decode("utf-8")
-
-                elif plc_datatype is not None and issubclass(plc_datatype, Structure):
-                    value = plc_datatype()
-                    fit_size = min(data_size, sizeof(value))
-                    memmove(addressof(value), addressof(data), fit_size)
-
-                elif plc_datatype is not None and issubclass(plc_datatype, Array):
-                    if data_size == sizeof(plc_datatype):
-                        value = list(plc_datatype.from_buffer_copy(bytes(data)))
-                    else:
-                        # invalid size
-                        value = None
-
-                elif plc_datatype not in DATATYPE_MAP:
-                    value = bytearray(data)
-
-                else:
-                    value = struct.unpack(DATATYPE_MAP[plc_datatype], bytearray(data))[
-                        0
-                    ]
-
-                if timestamp_as_filetime:
-                    timestamp = contents.nTimeStamp
-                else:
-                    timestamp = filetime_to_dt(contents.nTimeStamp)
-
-                return func(contents.hNotification, data_name, timestamp, value)
+                return func(hNotification, data_name, timestamp, value)
 
             return func_wrapper
 
         return notification_decorator
+
+    def notification_parser(
+        self, notification, plc_datatype, timestamp_as_filetime=False
+    ):
+        # type: (Any, Type, bool) -> (int, int, Any)
+        """Parse a notification.
+
+        Convert the data of the NotificationHeader into the fitting Python type.
+
+        :param notification: The notification we recieve from PLC datatype to be
+        converted. This can be any basic PLC datatype or a `ctypes.Structure`.
+        :param plc_datatype: The PLC datatype that needs to be converted. This can
+        be any basic PLC datatype or a `ctypes.Structure`.
+        :param timestamp_as_filetime: Whether the notification timestamp should be returned
+        as `datetime.datetime` (False) or Windows `FILETIME` as originally transmitted
+        via ADS (True). Be aware that the precision of `datetime.datetime` is limited to
+        microseconds, while FILETIME allows for 100 ns. This may be relevant when using
+        task cycle times such as 62.5 µs. Default: False.
+
+        :rtype: (int, int, Any)
+        :returns: notification handle, timestamp, value
+
+        **Usage**:
+
+        >>> import pyads
+        >>> from ctypes import size_of
+        >>>
+        >>> # Connect to the local TwinCAT PLC
+        >>> plc = pyads.Connection('127.0.0.1.1.1', 851)
+        >>> tag = {"GVL.myvalue": pyads.PLCTYPE_INT}
+        >>>
+        >>> # Create callback function that prints the value
+        >>> def mycallback(notification, data):
+        >>>     data_type = tag[data]
+        >>>     handle, timestamp, value = plc.notification_parser(notification, data_type)
+        >>>     print(value)
+        >>>
+        >>> with plc:
+        >>>     # Add notification with default settings
+        >>>     attr = pyads.NotificationAttrib(size_of(pyads.PLCTYPE_INT))
+        >>>
+        >>>     handles = plc.add_device_notification("GVL.myvalue", attr, mycallback)
+        >>>
+        >>>     # Remove notification
+        >>>     plc.del_device_notification(handles)
+        """
+        contents = notification.contents
+        data_size = contents.cbSampleSize
+        # Get dynamically sized data array
+        data = (c_ubyte * data_size).from_address(
+            addressof(contents) + SAdsNotificationHeader.data.offset
+        )
+
+        if plc_datatype == PLCTYPE_STRING:
+            # read only until null-termination character
+            value = bytearray(data).split(b"\0", 1)[0].decode("utf-8")
+
+        elif plc_datatype is not None and issubclass(plc_datatype, Structure):
+            value = plc_datatype()
+            fit_size = min(data_size, sizeof(value))
+            memmove(addressof(value), addressof(data), fit_size)
+
+        elif plc_datatype is not None and issubclass(plc_datatype, Array):
+            if data_size == sizeof(plc_datatype):
+                value = list(plc_datatype.from_buffer_copy(bytes(data)))
+            else:
+                # invalid size
+                value = None
+
+        elif plc_datatype not in DATATYPE_MAP:
+            value = bytearray(data)
+
+        else:
+            value = struct.unpack(DATATYPE_MAP[plc_datatype], bytearray(data))[0]
+
+        if timestamp_as_filetime:
+            timestamp = contents.nTimeStamp
+        else:
+            timestamp = filetime_to_dt(contents.nTimeStamp)
+
+        return contents.hNotification, timestamp, value

--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -633,9 +633,7 @@ class Connection(object):
     def ams_netid(self, netid):
         # type: (str) -> None
         if self._open:
-            raise AttributeError(
-                "Setting netid is not allowed while connection is open."
-            )
+            raise AttributeError("Setting netid is not allowed while connection is open.")
         self._adr.netid = netid
 
     @property
@@ -647,9 +645,7 @@ class Connection(object):
     def ams_port(self, port):
         # type: (int) -> None
         if self._open:
-            raise AttributeError(
-                "Setting port is not allowed while connection is open."
-            )
+            raise AttributeError("Setting port is not allowed while connection is open.")
         self._adr.port = port
 
     def __enter__(self):
@@ -1111,7 +1107,7 @@ class Connection(object):
 
             def func_wrapper(notification, data_name):
                 # type: (Any, str) -> None
-                hNotification, timestamp, value = self.notification_parser(
+                hNotification, timestamp, value = self.parse_notification(
                     notification, plc_datatype, timestamp_as_filetime
                 )
                 return func(hNotification, data_name, timestamp, value)
@@ -1120,7 +1116,7 @@ class Connection(object):
 
         return notification_decorator
 
-    def notification_parser(
+    def parse_notification(
         self, notification, plc_datatype, timestamp_as_filetime=False
     ):
         # type: (Any, Type, bool) -> (int, int, Any)


### PR DESCRIPTION
As mentioned in #143 - here is my take on moving the logic from the decorator into a different method to be used in other ways + in the decorator.

Hopefully this is up to par, I tried to get the documentation/type info in there as the rest of the code had it... not really that familiar with this process (Github) so could always take another run at it if needed.  I left all the tests alone as all the notification decorator tests just call this function, was not sure if I should poke into that at all or what would make sense to change that into since the decorator now calls this function. 