### PR TITLE
Add get_all_symbols function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## 3.3.0 [unreleased]
 
 ### Added
+* [#155](https://github.com/stlehmann/pyads/pull/155) Add get_all_symbols method to Connection
 
 ### Changed
 * [#150](https://github.com/stlehmann/pyads/pull/150) Use function annotations and variable annotations for type annotations

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -272,6 +272,20 @@ Toggle bitsize variables by address.
 >>> plc.write(INDEXGROUP_MEMORYBIT, 100*8 + 0, not data)
 ```
 
+### Get all symbols
+
+In order to get a list of the device's declared variables, use the `get_all_symbols` method.
+
+```python
+>>> symbols = plc.get_all_symbols()
+>>> print('\n'.join("%s: %s" % item for item in vars(symbols[0]).items()))
+index_group: 16448
+index_offset: 384800
+name: Constants.bFPUSupport
+symtype: BOOL
+comment: Does the target support multiple cores?
+```
+
 ### Device Notifications
 
 ADS supports device notifications, meaning you can pass a callback that gets

--- a/pyads/__init__.py
+++ b/pyads/__init__.py
@@ -32,6 +32,7 @@ from .constants import (
     PLCTYPE_DT,
     PLCTYPE_DWORD,
     PLCTYPE_INT,
+    PLCTYPE_LINT,
     PLCTYPE_LREAL,
     PLCTYPE_REAL,
     PLCTYPE_SINT,

--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -602,7 +602,10 @@ class Connection(object):
         return None
 
     def get_all_symbols(self) -> List[AdsSymbol]:
-        """Read all symbols from an ADS-device."""
+        """Read all symbols from an ADS-device.
+        
+        :return: List of AdsSymbols
+        """
         symbols = []
         if self._port is not None:
             symbol_size_msg = self.read(

--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -6,28 +6,45 @@
 :created on: 2018-06-11 18:15:53
 
 """
-import struct
-from collections import OrderedDict
-from ctypes import (
-    Array,
-    Structure,
-    addressof,
-    c_ubyte,
-    create_string_buffer,
-    memmove,
-    sizeof,
-)
+from typing import Optional, Union, Tuple, Any, Type, Callable, Dict, List
 from datetime import datetime
+import struct
+from ctypes import memmove, addressof, c_ubyte, Array, Structure, sizeof, create_string_buffer
+from collections import OrderedDict
 from functools import partial
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
+
+from .utils import decode_ads, platform_is_linux
+from .filetimes import filetime_to_dt
+
+from .pyads_ex import (
+    adsAddRoute,
+    adsAddRouteToPLC,
+    adsDelRoute,
+    adsPortOpenEx,
+    adsPortCloseEx,
+    adsGetLocalAddressEx,
+    adsSyncReadStateReqEx,
+    adsSyncReadDeviceInfoReqEx,
+    adsSyncWriteControlReqEx,
+    adsSyncWriteReqEx,
+    adsSyncReadWriteReqEx2,
+    adsSyncReadReqEx2,
+    adsGetHandle,
+    adsReleaseHandle,
+    adsSyncReadByNameEx,
+    adsSyncWriteByNameEx,
+    adsSyncAddDeviceNotificationReqEx,
+    adsSyncDelDeviceNotificationReqEx,
+    adsSyncSetTimeoutEx,
+    adsSetLocalAddress,
+    ADSError,
+)
 
 # noinspection PyUnresolvedReferences
 from .constants import (
     ADSIGRP_SYM_UPLOAD,
     ADSIGRP_SYM_UPLOADINFO2,
     ADSIOFFS_DEVDATA_ADSSTATE,
-    DATATYPE_MAP,
-    PLC_DEFAULT_STRING_SIZE,
     PLCTYPE_BOOL,
     PLCTYPE_BYTE,
     PLCTYPE_DATE,
@@ -45,40 +62,18 @@ from .constants import (
     PLCTYPE_UINT,
     PLCTYPE_USINT,
     PLCTYPE_WORD,
+    PLC_DEFAULT_STRING_SIZE,
+    DATATYPE_MAP,
 )
-from .filetimes import filetime_to_dt
-from .pyads_ex import (
-    ADSError,
-    adsAddRoute,
-    adsAddRouteToPLC,
-    adsDelRoute,
-    adsGetHandle,
-    adsGetLocalAddressEx,
-    adsPortCloseEx,
-    adsPortOpenEx,
-    adsReleaseHandle,
-    adsSetLocalAddress,
-    adsSyncAddDeviceNotificationReqEx,
-    adsSyncDelDeviceNotificationReqEx,
-    adsSyncReadByNameEx,
-    adsSyncReadDeviceInfoReqEx,
-    adsSyncReadReqEx2,
-    adsSyncReadStateReqEx,
-    adsSyncReadWriteReqEx2,
-    adsSyncSetTimeoutEx,
-    adsSyncWriteByNameEx,
-    adsSyncWriteControlReqEx,
-    adsSyncWriteReqEx,
-)
+
 from .structs import (
     AdsSymbol,
-    AdsVersion,
     AmsAddr,
+    SAmsNetId,
+    AdsVersion,
     NotificationAttrib,
     SAdsNotificationHeader,
-    SAmsNetId,
 )
-from .utils import decode_ads, platform_is_linux
 
 # custom types
 StructureDef = Tuple[

--- a/pyads/constants.py
+++ b/pyads/constants.py
@@ -7,23 +7,23 @@
 :created on 2018-06-11 18:15:53
 
 """
-from typing import Type, Dict
 from ctypes import (
     Array,
     c_bool,
-    c_ubyte,
-    c_int8,
-    c_uint8,
-    c_int16,
-    c_uint16,
-    c_int32,
-    c_uint32,
-    c_float,
-    c_double,
     c_char,
+    c_double,
+    c_float,
+    c_int8,
+    c_int16,
+    c_int32,
     c_int64,
+    c_ubyte,
+    c_uint8,
+    c_uint16,
+    c_uint32,
     c_uint64,
 )
+from typing import Dict, Type
 
 STRING_BUFFER = 1024
 PLC_DEFAULT_STRING_SIZE = 80
@@ -126,6 +126,9 @@ ADSIGRP_SYM_INFOBYNAMEEX = 0xF009
 ADSIGRP_SYM_DOWNLOAD = 0xF00A
 ADSIGRP_SYM_UPLOAD = 0xF00B
 ADSIGRP_SYM_UPLOADINFO = 0xF00C
+ADSIGRP_SYM_DOWNLOAD2 = 0xF00D
+ADSIGRP_SYM_DT_UPLOAD = 0xF00E
+ADSIGRP_SYM_UPLOADINFO2 = 0xF00F
 
 ADSIGRP_SYMNOTE = 0xF010  #: notification of named handle
 ADSIGRP_IOIMAGE_RWIB = 0xF020  #: read/write input byte(s)

--- a/pyads/constants.py
+++ b/pyads/constants.py
@@ -7,23 +7,23 @@
 :created on 2018-06-11 18:15:53
 
 """
+from typing import Type, Dict
 from ctypes import (
     Array,
     c_bool,
-    c_char,
-    c_double,
-    c_float,
-    c_int8,
-    c_int16,
-    c_int32,
-    c_int64,
     c_ubyte,
+    c_int8,
     c_uint8,
+    c_int16,
     c_uint16,
+    c_int32,
     c_uint32,
+    c_float,
+    c_double,
+    c_char,
+    c_int64,
     c_uint64,
 )
-from typing import Dict, Type
 
 STRING_BUFFER = 1024
 PLC_DEFAULT_STRING_SIZE = 80

--- a/pyads/structs.py
+++ b/pyads/structs.py
@@ -9,7 +9,8 @@
 
 """
 import typing
-from ctypes import Structure, c_ubyte, Union, c_uint16, c_uint32, c_uint64
+from ctypes import Structure, Union, c_ubyte, c_uint16, c_uint32, c_uint64
+
 from .constants import ADSTRANS_SERVERONCHA
 
 
@@ -39,6 +40,27 @@ class AdsVersion:
         self.version = stAdsVersion.version
         self.revision = stAdsVersion.revision
         self.build = stAdsVersion.build
+
+
+class AdsSymbol:
+    """Contains index group, index offset, name, symbol type, comment of ADS 
+    symbol.
+
+    :param index_group: Index group of symbol
+    :param index_offset: Index offset of symbol
+    :param name: Name of symbol
+    :param symtype: String representation of symbol type
+    :param comment: Comment of symbol
+
+    """
+
+    def __init__(self, index_group, index_offset, name, symtype, comment):
+        # type: (int, int, str, str, str) -> None
+        self.index_group = index_group
+        self.index_offset = index_offset
+        self.name = name
+        self.symtype = symtype
+        self.comment = comment
 
 
 class SAmsNetId(Structure):

--- a/pyads/testserver.py
+++ b/pyads/testserver.py
@@ -556,10 +556,10 @@ class AdvancedHandler(AbstractHandler):
                 response_value = struct.pack("II", symbol_count, response_length)
 
             elif index_group == constants.ADSIGRP_SYM_UPLOAD:
-                response_value = b''
+                response_value = b""
                 for (group, offset) in self._data.keys():
                     response_value += struct.pack("III", 120, group, offset)
-                    response_value += b'\x00' * 108
+                    response_value += b"\x00" * 108
 
             else:
                 # Create response of repeated 0x0F with a null

--- a/pyads/testserver.py
+++ b/pyads/testserver.py
@@ -550,6 +550,17 @@ class AdvancedHandler(AbstractHandler):
 
                 response_value = self._named_data[index_offset].value
 
+            elif index_group == constants.ADSIGRP_SYM_UPLOADINFO2:
+                symbol_count = len(self._data)
+                response_length = 120 * symbol_count
+                response_value = struct.pack("II", symbol_count, response_length)
+
+            elif index_group == constants.ADSIGRP_SYM_UPLOAD:
+                response_value = b''
+                for (group, offset) in self._data.keys():
+                    response_value += struct.pack("III", 120, group, offset)
+                    response_value += b'\x00' * 108
+
             else:
                 # Create response of repeated 0x0F with a null
                 # terminator for strings

--- a/pyads/utils.py
+++ b/pyads/utils.py
@@ -12,8 +12,7 @@
 import functools
 import sys
 import warnings
-
-from typing import Callable, Any, Optional
+from typing import Any, Callable, Optional
 
 
 def platform_is_linux() -> bool:
@@ -46,3 +45,8 @@ def deprecated(message: Optional[str] = None) -> Callable:
         return wrapper
 
     return decorator
+
+
+def decode_ads(message: bytes) -> str:
+    """Decode a string that in encoded in the format used by ADS."""
+    return message.decode("windows-1252").strip(" \t\n\r\0")

--- a/pyads/utils.py
+++ b/pyads/utils.py
@@ -49,5 +49,12 @@ def deprecated(message: Optional[str] = None) -> Callable:
 
 
 def decode_ads(message: bytes) -> str:
-    """Decode a string that in encoded in the format used by ADS."""
+    """
+    Decode a string that in encoded in the format used by ADS.
+
+    From Beckhoff documentation: 'A STRING constant is a string enclosed by
+    single quotation marks. The characters are encoded according to the Windows
+    1252 character set. As a subset of Windows-1252, the character set of
+    ISO/IEC 8859-1 is supported.'
+    """
     return message.decode("windows-1252").strip(" \t\n\r\0")

--- a/pyads/utils.py
+++ b/pyads/utils.py
@@ -12,7 +12,8 @@
 import functools
 import sys
 import warnings
-from typing import Any, Callable, Optional
+
+from typing import Callable, Any, Optional
 
 
 def platform_is_linux() -> bool:

--- a/tests/test_connection_class.py
+++ b/tests/test_connection_class.py
@@ -1020,6 +1020,18 @@ class AdsApiTestCaseAdvanced(unittest.TestCase):
             )
             self.assertEqual(value, 1)
 
+    def test_get_all_symbols(self):
+        with self.plc:
+            self.plc.write(
+                value="1",
+                index_group=123,
+                index_offset=0,
+                plc_datatype=constants.PLCTYPE_STRING
+            )
+            symbols = self.plc.get_all_symbols()
+            self.assertEqual(len(symbols), 1)
+            self.assertEqual(symbols[0].index_group, 123)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_connection_class.py
+++ b/tests/test_connection_class.py
@@ -1020,6 +1020,10 @@ class AdsApiTestCaseAdvanced(unittest.TestCase):
             )
             self.assertEqual(value, 1)
 
+    def test_get_all_symbols_empty(self):
+        with self.plc:
+            self.assertEqual(len(self.plc.get_all_symbols()), 0)
+
     def test_get_all_symbols_single(self):
         with self.plc:
             self.plc.write(
@@ -1028,10 +1032,6 @@ class AdsApiTestCaseAdvanced(unittest.TestCase):
             symbols = self.plc.get_all_symbols()
             self.assertEqual(len(symbols), 1)
             self.assertEqual(symbols[0].index_group, 123)
-
-    def test_get_all_symbols_empty(self):
-        with self.plc:
-            self.assertEqual(len(self.plc.get_all_symbols()), 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_connection_class.py
+++ b/tests/test_connection_class.py
@@ -1020,7 +1020,7 @@ class AdsApiTestCaseAdvanced(unittest.TestCase):
             )
             self.assertEqual(value, 1)
 
-    def test_get_all_symbols(self):
+    def test_get_all_symbols_single(self):
         with self.plc:
             self.plc.write(
                 value="1", index_group=123, index_offset=0, plc_datatype=constants.PLCTYPE_STRING
@@ -1028,6 +1028,10 @@ class AdsApiTestCaseAdvanced(unittest.TestCase):
             symbols = self.plc.get_all_symbols()
             self.assertEqual(len(symbols), 1)
             self.assertEqual(symbols[0].index_group, 123)
+
+    def test_get_all_symbols_empty(self):
+        with self.plc:
+            self.assertEqual(len(self.plc.get_all_symbols()), 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_connection_class.py
+++ b/tests/test_connection_class.py
@@ -1023,10 +1023,7 @@ class AdsApiTestCaseAdvanced(unittest.TestCase):
     def test_get_all_symbols(self):
         with self.plc:
             self.plc.write(
-                value="1",
-                index_group=123,
-                index_offset=0,
-                plc_datatype=constants.PLCTYPE_STRING
+                value="1", index_group=123, index_offset=0, plc_datatype=constants.PLCTYPE_STRING
             )
             symbols = self.plc.get_all_symbols()
             self.assertEqual(len(symbols), 1)


### PR DESCRIPTION
I was looking for a way to retrieve all symbol information and came across https://github.com/stlehmann/pyads/issues/124, indicating this was not a feature. I searched the ADS repo for `AdsReadSymbolInfo` which https://github.com/stlehmann/pyads/issues/124 implies exists, but I could not find it.

The ability to read symbols was a feature I had used before in the [`counsyl-pyads`](https://github.com/counsyl/counsyl-pyads) package, so I decided to port over [the logic](https://github.com/counsyl/counsyl-pyads/blob/e6fafd946b894c22e555a09c97fcd301844f212a/counsyl_pyads/adsclient.py#L313-L358). There's also logic in that package that allows you to read a symbol by name, but I decided against adding that for now unless there's a request to do so.

Here's a sample when tested with a PLC running TC3:
```
>>> symbols=plc.get_all_symbols()
>>> print('\n'.join("%s: %s" % item for item in vars(symbols[0]).items()))
index_group: 16448
index_offset: 384800
name: Constants.bFPUSupport
symtype: BOOL
comment: Does the target support multiple cores?
```

You may also notice that the import ordering was slightly modified to be in alphabetical order by `isort`. If this is not a desired change, I can revert it.