### PR TITLE
Add a sleep after starting advanced handler server

### DIFF
--- a/tests/test_connection_class.py
+++ b/tests/test_connection_class.py
@@ -975,6 +975,9 @@ class AdsApiTestCaseAdvanced(unittest.TestCase):
         cls.test_server = AdsTestServer(AdvancedHandler(), logging=False)
         cls.test_server.start()
 
+        # wait a bit otherwise error might occur
+        time.sleep(1)
+
     @classmethod
     def tearDownClass(cls):
         cls.test_server.stop()


### PR DESCRIPTION
Adds a sleep to address the test error @chrisbeardy noted in https://github.com/stlehmann/pyads/pull/157 and https://github.com/stlehmann/pyads/pull/159