### PR TITLE
Destructor for pyads.Connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 * [#169](https://github.com/stlehmann/pyads/pull/169) Add adsGetNetIdForPLC to pyads_ex
+* [#179](https://github.com/stlehmann/pyads/pull/179) Added destructor to `pyads.Connection`
 
 ### Changed
 

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -101,6 +101,19 @@ the route to the testserver needs to be added from another python console.
 >>> plc.close()
 ```
 
+The connection will also be closed automatically when the object runs out of scope, making `plc.close()` optional.
+
+A context notation (using `with:`) can also be used to open the connection:
+
+```python
+import pyads
+plc = pyads.Connection('127.0.0.1.1.1', pyads.PORT_SPS1)
+with plc:
+    # ...
+```
+
+The context manager will make sure the connection is closed, either when the `with` clause runs out, or an uncaught error is thrown.
+
 ### Read and write values by name
 
 ```python

--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -497,6 +497,14 @@ class Connection(object):
         """Close on leaving with-block."""
         self.close()
 
+    def __del__(self) -> None:
+        """Class destructor.
+
+        Make sure to close the connection when an instance runs out of scope.
+        """
+        # If the connection is already closed, nothing new will happen
+        self.close()
+
     def open(self) -> None:
         """Connect to the TwinCAT message router."""
         if self._open:


### PR DESCRIPTION
Adding a very simple destructor to `pyads.Connection`. Ties in with #178 