### PR TITLE
Make AdsSymbol even more pythonic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 * fixed error with source distribution not containing adslib directory
-
+* [#192](https://github.com/stlehmann/pyads/pull/192) make AdsSymbol even more pythonic
+  * replace AdsSymbol.set_auto_update function by AdsSymbol.auto_update property
+  * make AdsSymbol.value a property
+  * AdsSymbol.value setter writes to plc if AdsSymbol.auto_update is True  
+ 
 ### Removed
 
 ## 3.3.1

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -197,7 +197,7 @@ symbol.add_device_notification(my_func, attr=attr, user_handle=user_handle)
 A built-in notification is available to automatically update the symbol buffer based on the remote value. This is disabled by default, enable it with:
 
 ```python
-symbol.set_auto_update(True)
+symbol.auto_update = True
 ```
 
 This will create a new notification callback to update `symbol.value`. This can be efficient if the remote variable changes less frequently then your code runs. The number of notification callbacks will then be less than what the number of read operations would have been. 
@@ -205,8 +205,10 @@ This will create a new notification callback to update `symbol.value`. This can 
 It can be disabled again with:
 
 ```python
-symbol.set_auto_update(False)
+symbol.auto_update = False
 ```
+
+Using auto_update will also write the value immediately to the plc when `symbol.value` is changed.
 
 Take care that `symbol.clear_notifications()` will *also* remove the auto-update notification. Like all symbol notifications, the auto-update will also be cleared automatically in the object destructor.
 

--- a/pyads/symbol.py
+++ b/pyads/symbol.py
@@ -308,6 +308,7 @@ class AdsSymbol:
 
         """
         self._value = val
+
         # write value to plc if auto_update is enabled
-        if self._auto_update_handle is not None:
+        if self.auto_update:
             self.write(val)

--- a/pyads/symbol.py
+++ b/pyads/symbol.py
@@ -8,9 +8,10 @@ the circular dependencies.
 import re
 from ctypes import sizeof
 from typing import TYPE_CHECKING, Any, Optional, List, Tuple, Callable
+
+from . import constants  # To access all constants, use package notation
 from .pyads_ex import adsGetSymbolInfo
 from .structs import NotificationAttrib
-from . import constants  # To access all constants, use package notation
 
 # ads.Connection relies on structs.AdsSymbol (but in type hints only), so use
 # this 'if' to only include it when type hinting (False during execution)

--- a/pyads/symbol.py
+++ b/pyads/symbol.py
@@ -104,7 +104,7 @@ class AdsSymbol:
         if self.symbol_type is not None:
             self.plc_type = AdsSymbol.get_type_from_str(self.symbol_type)
 
-        self.set_auto_update(auto_update)
+        self.auto_update = auto_update
 
     def _create_symbol_from_info(self) -> None:
         """Look up remaining info from the remote
@@ -215,23 +215,6 @@ class AdsSymbol:
             self._plc.del_device_notification(*handles)
             self._handles_list.remove(handles)
 
-    def set_auto_update(self, auto_update: bool) -> None:
-        """Enable or disable auto-update of buffered value
-
-        This automatic update is done through a device notification. This
-        can be efficient when a remote variables changes its values less often
-        than your code run.
-        Clearing all device notifications will also disable auto-update.
-        Automatic update is disabled by default.
-        """
-        if auto_update and self._auto_update_handle is None:
-            self._auto_update_handle = self.add_device_notification(
-                self._value_callback
-            )
-        elif not auto_update and self._auto_update_handle is not None:
-            self.del_device_notification(self._auto_update_handle)
-            self._auto_update_handle = None
-
     def _value_callback(self, notification: Any, data_name: Any) -> None:
         """Internal callback used by auto-update"""
 
@@ -287,6 +270,30 @@ class AdsSymbol:
         # error when they are being addressed
 
         return None
+
+    @property
+    def auto_update(self) -> Any:
+        """Return True if auto_update is enabled for this symbol."""
+        return self._auto_update_handle is not None
+
+    @auto_update.setter
+    def auto_update(self, value: bool) -> None:
+        """Enable or disable auto-update of the buffered value.
+
+        This automatic update is done through a device notification. This
+        can be efficient when a remote variables changes its values less often
+        than your code run.
+
+        Clearing all device notifications will also disable auto-update.
+        Automatic update is disabled by default.
+        """
+        if value and self._auto_update_handle is None:
+            self._auto_update_handle = self.add_device_notification(
+                self._value_callback
+            )
+        elif not value and self._auto_update_handle is not None:
+            self.del_device_notification(self._auto_update_handle)
+            self._auto_update_handle = None
 
     @property
     def value(self) -> Any:

--- a/tests/test_symbol.py
+++ b/tests/test_symbol.py
@@ -425,11 +425,27 @@ class AdsSymbolTestCase(unittest.TestCase):
             pointer(notification),
             (self.test_var.index_group, self.test_var.index_offset),
         )
-
         self.assertEqual(symbol.value, 5334.1545)
+
+        # test immediate writing to plc if auto_update is True
+        symbol.value = 123.456
+        r_value = self.plc.read(
+            symbol.index_group,
+            symbol.index_offset,
+            symbol.plc_type,
+        )
+        self.assertEqual(symbol.value, r_value)
 
         symbol.auto_update = False
         self.assertIsNone(symbol._auto_update_handle)
+        symbol.value = 0.0
+        r_value = self.plc.read(
+            symbol.index_group,
+            symbol.index_offset,
+            symbol.plc_type,
+        )
+        self.assertEqual(r_value, 123.456)
+
 
 
 class TypesTestCase(unittest.TestCase):

--- a/tests/test_symbol.py
+++ b/tests/test_symbol.py
@@ -415,8 +415,9 @@ class AdsSymbolTestCase(unittest.TestCase):
         symbol = self.plc.get_symbol(self.test_var.name)
         self.assertIsNone(symbol._auto_update_handle)
 
-        symbol.set_auto_update(True)
+        symbol.auto_update = True
         self.assertIsNotNone(symbol._auto_update_handle)
+        self.assertEqual(symbol.auto_update, True)
 
         # Simulate value callback
         notification = create_notification_struct(struct.pack("<d", 5334.1545))
@@ -427,7 +428,7 @@ class AdsSymbolTestCase(unittest.TestCase):
 
         self.assertEqual(symbol.value, 5334.1545)
 
-        symbol.set_auto_update(False)
+        symbol.auto_update = False
         self.assertIsNone(symbol._auto_update_handle)
 
 


### PR DESCRIPTION
The purpose of this PR is to make the great AdsSymbol class even more Pythonic by:

* replacing setter/getter functions by properties
* Allowing immediate writing of the value to the plc if auto_update is True