### PR TITLE
Read/write by name without datatype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## 3.3.4 [unreleased]
 
 ### Added
-* [195](https://github.com/stlehmann/pyads/pull/195) Read/write by name without passing the datatype
+* [#195](https://github.com/stlehmann/pyads/pull/195) Read/write by name without passing the datatype
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## 3.3.4 [unreleased]
 
 ### Added
+* [195](https://github.com/stlehmann/pyads/pull/195) Read/write by name without passing the datatype
 
 ### Changed
 

--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -342,9 +342,9 @@ def dict_from_bytes(
                     if str_len is None:
                         str_len = PLC_DEFAULT_STRING_SIZE
                     var_array.append(
-                        bytearray(byte_list[index : (index + (str_len + 1))])
-                        .partition(b"\0")[0]
-                        .decode("utf-8")
+                        bytearray(byte_list[index: (index + (str_len + 1))])
+                            .partition(b"\0")[0]
+                            .decode("utf-8")
                     )
                     index += str_len + 1
                 elif plc_datatype not in DATATYPE_MAP:
@@ -354,7 +354,7 @@ def dict_from_bytes(
                     var_array.append(
                         struct.unpack(
                             DATATYPE_MAP[plc_datatype],
-                            bytearray(byte_list[index : (index + n_bytes)]),
+                            bytearray(byte_list[index: (index + n_bytes)]),
                         )[0]
                     )
                     index += n_bytes
@@ -753,10 +753,10 @@ class Connection(object):
 
             for idx in range(sym_count):
                 read_length, index_group, index_offset = struct.unpack(
-                    "III", symbol_list_msg[ptr + 0 : ptr + 12]
+                    "III", symbol_list_msg[ptr + 0: ptr + 12]
                 )
                 name_length, type_length, comment_length = struct.unpack(
-                    "HHH", symbol_list_msg[ptr + 24 : ptr + 30]
+                    "HHH", symbol_list_msg[ptr + 24: ptr + 30]
                 )
 
                 name_start_ptr = ptr + 30
@@ -856,7 +856,6 @@ class Connection(object):
         :param data_names: list of variable names to be read
         :type data_names: list[str]
         :param bool cache_symbol_info: when True, symbol info will be cached for future reading
-
         :return adsSumRead: A dictionary containing variable names from data_names as keys and values read from PLC for each variable
         :rtype dict(str, Any)
 

--- a/pyads/testserver.py
+++ b/pyads/testserver.py
@@ -556,7 +556,7 @@ class PLCVariable:
         :param ads_type: constants.PLCTYPE_*
         :param symbol_type: PLC-style name of type
         """
-        self.name = name
+        self.name = name.strip('\x00')
         self.value = value  # type: bytes
         # Variable value is stored in binary!
 

--- a/tests/test_connection_class.py
+++ b/tests/test_connection_class.py
@@ -627,6 +627,9 @@ class AdsConnectionClassTestCase(unittest.TestCase):
         handle_name = "TestHandle"
         value = "Test Value"
 
+        # return None if connection is closed
+        self.assertIsNone(self.plc.write_by_name("test_var", 1, pyads.PLCTYPE_INT))
+
         with self.plc:
             self.plc.write_by_name(handle_name, value, constants.PLCTYPE_STRING)
 

--- a/tests/test_connection_class.py
+++ b/tests/test_connection_class.py
@@ -568,6 +568,16 @@ class AdsConnectionClassTestCase(unittest.TestCase):
         with self.plc:
             self.plc.release_handle(handle)
 
+    def test_read_by_name_without_datatype(self) -> None:
+        """Test read by name without passing the datatype."""
+        with self.plc:
+            # read twice to show cachinng
+            read_value = self.plc.read_by_name("TestVar1")
+            read_value2 = self.plc.read_by_name("TestVar1")
+
+        self.assertEqual(read_value, 1)
+        self.assertEqual(read_value2, 1)
+
     def test_read_structure_by_name(self):
         # type: () -> None
         """Test read by structure method"""
@@ -675,6 +685,16 @@ class AdsConnectionClassTestCase(unittest.TestCase):
 
         with self.plc:
             self.plc.release_handle(handle)
+
+    def test_write_by_name_without_datatype(self) -> None:
+        """Test read by name without passing the datatype."""
+        with self.plc:
+            # write twice to show caching
+            self.plc.write_by_name("TestVar1", 41)
+            self.plc.write_by_name("TestVar1", 42)
+            read_value = self.plc.read_by_name("TestVar1")
+
+        self.assertEqual(read_value, 42)
 
     def test_write_structure_by_name(self):
         # type: () -> None

--- a/tests/test_connection_class.py
+++ b/tests/test_connection_class.py
@@ -1270,12 +1270,16 @@ class AdsApiTestCaseAdvanced(unittest.TestCase):
         with self.plc:
             # create variable on testserver
             self.plc.write_by_name("test_var", 42, pyads.PLCTYPE_INT)
-            # read twice to show cachinng
+
+            # read twice to show caching
             read_value = self.plc.read_by_name("test_var")
             read_value2 = self.plc.read_by_name("test_var")
+            self.assertEqual(read_value, 42)
+            self.assertEqual(read_value2, 42)
 
-        self.assertEqual(read_value, 42)
-        self.assertEqual(read_value2, 42)
+            # read without caching
+            read_value = self.plc.read_by_name("test_var", cache_symbol_info=False)
+            self.assertEqual(read_value, 42)
 
     def test_write_by_name_without_datatype(self) -> None:
         """Test read by name without passing the datatype."""
@@ -1286,8 +1290,12 @@ class AdsApiTestCaseAdvanced(unittest.TestCase):
             self.plc.write_by_name("test_var", 42)
             self.plc.write_by_name("test_var", 42)
             read_value = self.plc.read_by_name("test_var")
+            self.assertEqual(read_value, 42)
 
-        self.assertEqual(read_value, 42)
+            # write without caching
+            self.plc.write_by_name("test_var", 43, cache_symbol_info=False)
+            read_value = self.plc.read_by_name("test_var")
+            self.assertEqual(read_value, 43)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR enables read/write by name without needing to provide the datatype. It also allows to specifiy whether the type will be looked up or cached via cache_symbol_info parameter.