### PR TITLE
Testserver: SUMUP_READ and SUMUP_WRITE with variable length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * [#195](https://github.com/stlehmann/pyads/pull/195) Read/write by name without passing the datatype
 
 ### Changed
+* [#202](https://github.com/stlehmann/pyads/pull/202) Testserver now support variable sumread and sumwrite with 
+  variable length for uint8 and string datatypes
 
 ### Removed
 

--- a/pyads/testserver.py
+++ b/pyads/testserver.py
@@ -492,17 +492,16 @@ class BasicHandler(AbstractHandler):
                     )
 
             elif index_group == constants.ADSIGRP_SUMUP_READ:
-                n_reads = len(write_data) / 12
-                for i in range(n_reads):
-                    index_group = write_data[i:i+4]
-                    index_offset = write_data[i+4:i+8]
-                    data_type = write_data[i+8:i+12]
+                n_reads = len(write_data) // 12
 
                 # Could be improved to handle variable length requests
-                response_value = struct.pack(
-                    "<IIIIBB4sB", 0, 0, 0, 1, 1, 2,
-                    ("test" + "\x00").encode("utf-8"), 0
-                )
+                fmt = "<" + n_reads * "I"
+                vals = n_reads * [0]
+                for i in range(n_reads):
+                    fmt += "B"
+                    vals.append(i + 1)
+                response_value = struct.pack(fmt, *vals)
+
 
             elif index_group == constants.ADSIGRP_SUMUP_WRITE:
                 response_value = struct.pack("<IIII", 0, 0, 0, 1)

--- a/pyads/testserver.py
+++ b/pyads/testserver.py
@@ -492,6 +492,12 @@ class BasicHandler(AbstractHandler):
                     )
 
             elif index_group == constants.ADSIGRP_SUMUP_READ:
+                n_reads = len(write_data) / 12
+                for i in range(n_reads):
+                    index_group = write_data[i:i+4]
+                    index_offset = write_data[i+4:i+8]
+                    data_type = write_data[i+8:i+12]
+
                 # Could be improved to handle variable length requests
                 response_value = struct.pack(
                     "<IIIIBB4sB", 0, 0, 0, 1, 1, 2,

--- a/pyads/testserver.py
+++ b/pyads/testserver.py
@@ -504,7 +504,10 @@ class BasicHandler(AbstractHandler):
 
 
             elif index_group == constants.ADSIGRP_SUMUP_WRITE:
-                response_value = struct.pack("<IIII", 0, 0, 0, 1)
+                n_writes = len(write_data) // 12
+                fmt = "<" + n_writes * "I"
+                vals = n_writes * [0]
+                response_value = struct.pack(fmt, *vals)
 
             elif response_length > 0:
                 # Create response of repeated 0x0F with a null terminator for strings

--- a/pyads/testserver.py
+++ b/pyads/testserver.py
@@ -493,15 +493,21 @@ class BasicHandler(AbstractHandler):
 
             elif index_group == constants.ADSIGRP_SUMUP_READ:
                 n_reads = len(write_data) // 12
-
-                # Could be improved to handle variable length requests
                 fmt = "<" + n_reads * "I"
-                vals = n_reads * [0]
-                for i in range(n_reads):
-                    fmt += "B"
-                    vals.append(i + 1)
-                response_value = struct.pack(fmt, *vals)
+                vals = [0 for i in range(n_reads)]
 
+                for i in range(n_reads):
+                    buf = write_data[i * 12 + 8:i * 12 + 12]
+                    is_str = struct.unpack("<I", buf)[0] == 5
+
+                    if is_str:
+                        fmt += "4s"
+                        vals.append(b"test\x00")
+                    else:
+                        fmt += "B"
+                        vals.append(i + 1)
+                response_value = struct.pack(fmt, *vals)
+                print(response_value)
 
             elif index_group == constants.ADSIGRP_SUMUP_WRITE:
                 n_writes = len(write_data) // 12

--- a/pyads/testserver.py
+++ b/pyads/testserver.py
@@ -817,10 +817,10 @@ class AdvancedHandler(AbstractHandler):
             # type: () -> bytes
             """Handle read-state request."""
             logger.info("Command received: READ_STATE")
-            ads_state = struct.pack("<I", constants.ADSSTATE_RUN)
+            ads_state = struct.pack("<H", constants.ADSSTATE_RUN)
             # I don't know what an appropriate value for device state is.
             # I suspect it may be unused..
-            device_state = struct.pack("<I", 0)
+            device_state = struct.pack("<H", 0)
             return ads_state + device_state
 
         def handle_writectrl():

--- a/tests/test_connection_class.py
+++ b/tests/test_connection_class.py
@@ -1102,7 +1102,7 @@ class AdsConnectionClassTestCase(unittest.TestCase):
             "i1": 1,
             "i2": 2,
             "i3": 3,
-            "i4": 4,
+            "str_test": "test",
         }
 
         with self.plc:
@@ -1126,7 +1126,7 @@ class AdsConnectionClassTestCase(unittest.TestCase):
             "i1": "no error",
             "i2": "no error",
             "i3": "no error",
-            "i4": "no error",
+            "str_test": "no error",
         }
         self.assertEqual(errors, expected_result)
 
@@ -1134,8 +1134,8 @@ class AdsConnectionClassTestCase(unittest.TestCase):
         variables = {
             "i1": 1,
             "i2": 2,
-            "i3": 4,
-            "i4": 3,
+            "i3": 3,
+            "str_test": "test",
         }
 
         with self.plc:
@@ -1159,7 +1159,7 @@ class AdsConnectionClassTestCase(unittest.TestCase):
             "i1": "no error",
             "i2": "no error",
             "i3": "no error",
-            "i4": "no error",
+            "str_test": "no error",
         }
         self.assertEqual(errors, expected_result)
 

--- a/tests/test_connection_class.py
+++ b/tests/test_connection_class.py
@@ -1036,7 +1036,7 @@ class AdsConnectionClassTestCase(unittest.TestCase):
         self.assert_command_id(requests[1], constants.ADSCOMMAND_WRITE)
 
     def test_read_list(self):
-        variables = ["i1", "i2", "i3", "i4"]
+        variables = ["i1", "i2", "i3", "str_test"]
 
         # Read twice to show caching
         with self.plc:
@@ -1062,7 +1062,7 @@ class AdsConnectionClassTestCase(unittest.TestCase):
             "i1": 1,
             "i2": 2,
             "i3": 3,
-            "i4": 4,
+            "str_test": "test",
         }
         self.assertEqual(read_values, expected_result)
         self.assertEqual(read_values2, expected_result)
@@ -1070,7 +1070,7 @@ class AdsConnectionClassTestCase(unittest.TestCase):
     def test_read_list_without_cache(self):
 
         # Repeat the test without cache
-        variables = ["i1", "i2", "i3", "i4"]
+        variables = ["i1", "i2", "i3", "str_test"]
 
         with self.plc:
             read_values = self.plc.read_list_by_name(variables, cache_symbol_info=False)
@@ -1093,7 +1093,7 @@ class AdsConnectionClassTestCase(unittest.TestCase):
             "i1": 1,
             "i2": 2,
             "i3": 3,
-            "i4": 4,
+            "str_test": "test",
         }
         self.assertEqual(read_values, expected_result)
 

--- a/tests/test_connection_class.py
+++ b/tests/test_connection_class.py
@@ -1036,7 +1036,7 @@ class AdsConnectionClassTestCase(unittest.TestCase):
         self.assert_command_id(requests[1], constants.ADSCOMMAND_WRITE)
 
     def test_read_list(self):
-        variables = ["TestVar1", "TestVar2", "str_TestVar3", "TestVar4"]
+        variables = ["i1", "i2", "i3", "i4"]
 
         # Read twice to show caching
         with self.plc:
@@ -1059,10 +1059,10 @@ class AdsConnectionClassTestCase(unittest.TestCase):
 
         # Expected result
         expected_result = {
-            "TestVar1": 1,
-            "TestVar2": 2,
-            "str_TestVar3": "test",
-            "TestVar4": "Internal error",
+            "i1": 1,
+            "i2": 2,
+            "i3": 3,
+            "i4": 4,
         }
         self.assertEqual(read_values, expected_result)
         self.assertEqual(read_values2, expected_result)
@@ -1070,7 +1070,7 @@ class AdsConnectionClassTestCase(unittest.TestCase):
     def test_read_list_without_cache(self):
 
         # Repeat the test without cache
-        variables = ["TestVar1", "TestVar2", "str_TestVar3", "TestVar4"]
+        variables = ["i1", "i2", "i3", "i4"]
 
         with self.plc:
             read_values = self.plc.read_list_by_name(variables, cache_symbol_info=False)
@@ -1090,19 +1090,19 @@ class AdsConnectionClassTestCase(unittest.TestCase):
 
         # Expected result
         expected_result = {
-            "TestVar1": 1,
-            "TestVar2": 2,
-            "str_TestVar3": "test",
-            "TestVar4": "Internal error",
+            "i1": 1,
+            "i2": 2,
+            "i3": 3,
+            "i4": 4,
         }
         self.assertEqual(read_values, expected_result)
 
     def test_write_list(self):
         variables = {
-            "TestVar1": 1,
-            "TestVar2": 2,
-            "str_TestVar3": "test",
-            "TestVar4": 3,
+            "i1": 1,
+            "i2": 2,
+            "i3": 3,
+            "i4": 4,
         }
 
         with self.plc:
@@ -1123,19 +1123,19 @@ class AdsConnectionClassTestCase(unittest.TestCase):
 
         # Expected result
         expected_result = {
-            "TestVar1": "no error",
-            "TestVar2": "no error",
-            "str_TestVar3": "no error",
-            "TestVar4": "Internal error",
+            "i1": "no error",
+            "i2": "no error",
+            "i3": "no error",
+            "i4": "no error",
         }
         self.assertEqual(errors, expected_result)
 
     def test_write_list_without_cache(self):
         variables = {
-            "TestVar1": 1,
-            "TestVar2": 2,
-            "str_TestVar3": "test",
-            "TestVar4": 3,
+            "i1": 1,
+            "i2": 2,
+            "i3": 4,
+            "i4": 3,
         }
 
         with self.plc:
@@ -1156,10 +1156,10 @@ class AdsConnectionClassTestCase(unittest.TestCase):
 
         # Expected result
         expected_result = {
-            "TestVar1": "no error",
-            "TestVar2": "no error",
-            "str_TestVar3": "no error",
-            "TestVar4": "Internal error",
+            "i1": "no error",
+            "i2": "no error",
+            "i3": "no error",
+            "i4": "no error",
         }
         self.assertEqual(errors, expected_result)
 


### PR DESCRIPTION
This PR allows to have variable length sumread and sumwrite requests with the testserver. To keep things simple the testserver handles only uint8 and str data. The returned string is always "test".