### PR TITLE
removed duplicate tests and added addtional asserts to existing tests

### DIFF
--- a/tests/test_connection_class.py
+++ b/tests/test_connection_class.py
@@ -1049,7 +1049,7 @@ class AdsConnectionClassTestCase(unittest.TestCase):
         # Assert that the server received - 4x symbol info, 1x sum read, 1x sum read (second)
         self.assertEqual(len(requests), 6)
 
-        # Assert that all commands are read write - 2x symbol info, 1x sum read
+        # Assert that all commands are read write
         self.assert_command_id(requests[0], constants.ADSCOMMAND_READWRITE)
         self.assert_command_id(requests[1], constants.ADSCOMMAND_READWRITE)
         self.assert_command_id(requests[2], constants.ADSCOMMAND_READWRITE)
@@ -1074,19 +1074,25 @@ class AdsConnectionClassTestCase(unittest.TestCase):
 
         with self.plc:
             read_values = self.plc.read_list_by_name(variables, cache_symbol_info=False)
+            read_values2 = self.plc.read_list_by_name(variables)
 
         # Retrieve list of received requests from server
         requests = self.test_server.request_history
 
-        # Assert that the server received - 4x symbol info, 1x sum read (second)
-        self.assertEqual(len(requests), 5)
+        # Assert that the server received - 4x symbol info, 1x sum read, 4x symbol info (as no cache), 1 x sum read
+        self.assertEqual(len(requests), 10)
 
-        # Assert that all commands are read write - 2x symbol info, 1x sum read
+        # Assert that all commands are read write
         self.assert_command_id(requests[0], constants.ADSCOMMAND_READWRITE)
         self.assert_command_id(requests[1], constants.ADSCOMMAND_READWRITE)
         self.assert_command_id(requests[2], constants.ADSCOMMAND_READWRITE)
         self.assert_command_id(requests[3], constants.ADSCOMMAND_READWRITE)
         self.assert_command_id(requests[4], constants.ADSCOMMAND_READWRITE)
+        self.assert_command_id(requests[5], constants.ADSCOMMAND_READWRITE)
+        self.assert_command_id(requests[6], constants.ADSCOMMAND_READWRITE)
+        self.assert_command_id(requests[7], constants.ADSCOMMAND_READWRITE)
+        self.assert_command_id(requests[8], constants.ADSCOMMAND_READWRITE)
+        self.assert_command_id(requests[9], constants.ADSCOMMAND_READWRITE)
 
         # Expected result
         expected_result = {
@@ -1096,6 +1102,7 @@ class AdsConnectionClassTestCase(unittest.TestCase):
             "str_test": "test",
         }
         self.assertEqual(read_values, expected_result)
+        self.assertEqual(read_values2, expected_result)
 
     def test_read_list_ads_sub_commands(self):
         variables = ["TestVar1", "TestVar2", "str_TestVar3", "TestVar4"]
@@ -1109,7 +1116,7 @@ class AdsConnectionClassTestCase(unittest.TestCase):
         # Assert that the server received - 4x symbol info, 2x sum read (as sub commands split request into two reads)
         self.assertEqual(len(requests), 6)
 
-        # Assert that all commands are read write - 4x symbol info, 2x sum read
+        # Assert that all commands are read write
         self.assert_command_id(requests[0], constants.ADSCOMMAND_READWRITE)
         self.assert_command_id(requests[1], constants.ADSCOMMAND_READWRITE)
         self.assert_command_id(requests[2], constants.ADSCOMMAND_READWRITE)
@@ -1126,36 +1133,7 @@ class AdsConnectionClassTestCase(unittest.TestCase):
         }
         self.assertEqual(read_values, expected_result)
 
-    def test_read_list_ads_sub_commands(self):
-        variables = ["TestVar1", "TestVar2", "str_TestVar3", "TestVar4"]
-
-        with self.plc:
-            read_values = self.plc.read_list_by_name(variables, ads_sub_commands=2)
-
-        # Retrieve list of received requests from server
-        requests = self.test_server.request_history
-
-        # Assert that the server received - 4x symbol info, 2x sum read (as sub commands split request into two reads)
-        self.assertEqual(len(requests), 6)
-
-        # Assert that all commands are read write - 4x symbol info, 2x sum read
-        self.assert_command_id(requests[0], constants.ADSCOMMAND_READWRITE)
-        self.assert_command_id(requests[1], constants.ADSCOMMAND_READWRITE)
-        self.assert_command_id(requests[2], constants.ADSCOMMAND_READWRITE)
-        self.assert_command_id(requests[3], constants.ADSCOMMAND_READWRITE)
-        self.assert_command_id(requests[4], constants.ADSCOMMAND_READWRITE)
-        self.assert_command_id(requests[5], constants.ADSCOMMAND_READWRITE)
-
-        # Expected result
-        expected_result = {
-            "TestVar1": 1,
-            "TestVar2": 2,
-            "str_TestVar3": "test",
-            "TestVar4": 2,
-        }
-        self.assertEqual(read_values, expected_result)
-
-    def test_write_list(self):
+    def test_write_list_without_cache(self):
         variables = {
             "i1": 1,
             "i2": 2,
@@ -1165,19 +1143,25 @@ class AdsConnectionClassTestCase(unittest.TestCase):
 
         with self.plc:
             errors = self.plc.write_list_by_name(variables, cache_symbol_info=False)
+            errors2 = self.plc.write_list_by_name(variables)
 
         # Retrieve list of received requests from server
         requests = self.test_server.request_history
 
-        # Assert that the server received 3 requests
-        self.assertEqual(len(requests), 5)
+        # Assert that the server received - 4x symbol info, 1x sum write, 4x symbol info (as no cache), 1x sum write
+        self.assertEqual(len(requests), 10)
 
-        # Assert that all commands are read write - 4x symbol info, 1x sum write
+        # Assert that all commands are read write
         self.assert_command_id(requests[0], constants.ADSCOMMAND_READWRITE)
         self.assert_command_id(requests[1], constants.ADSCOMMAND_READWRITE)
         self.assert_command_id(requests[2], constants.ADSCOMMAND_READWRITE)
         self.assert_command_id(requests[3], constants.ADSCOMMAND_READWRITE)
         self.assert_command_id(requests[4], constants.ADSCOMMAND_READWRITE)
+        self.assert_command_id(requests[5], constants.ADSCOMMAND_READWRITE)
+        self.assert_command_id(requests[6], constants.ADSCOMMAND_READWRITE)
+        self.assert_command_id(requests[7], constants.ADSCOMMAND_READWRITE)
+        self.assert_command_id(requests[8], constants.ADSCOMMAND_READWRITE)
+        self.assert_command_id(requests[9], constants.ADSCOMMAND_READWRITE)
 
         # Expected result
         expected_result = {
@@ -1187,8 +1171,9 @@ class AdsConnectionClassTestCase(unittest.TestCase):
             "str_test": "no error",
         }
         self.assertEqual(errors, expected_result)
+        self.assertEqual(errors2, expected_result)
 
-    def test_write_list_without_cache(self):
+    def test_write_list(self):
         variables = {
             "i1": 1,
             "i2": 2,
@@ -1202,10 +1187,10 @@ class AdsConnectionClassTestCase(unittest.TestCase):
         # Retrieve list of received requests from server
         requests = self.test_server.request_history
 
-        # Assert that the server received 3 requests
+        # Assert that the server received 5 requests 4x symbol info, 1x sum write
         self.assertEqual(len(requests), 5)
 
-        # Assert that all commands are read write - 4x symbol info, 1x sum write
+        # Assert that all commands are read write
         self.assert_command_id(requests[0], constants.ADSCOMMAND_READWRITE)
         self.assert_command_id(requests[1], constants.ADSCOMMAND_READWRITE)
         self.assert_command_id(requests[2], constants.ADSCOMMAND_READWRITE)
@@ -1238,41 +1223,7 @@ class AdsConnectionClassTestCase(unittest.TestCase):
         # Assert that the server received 6 requests - 4x symbol info, 2x write as split by subcommands
         self.assertEqual(len(requests), 6)
 
-        # Assert that all commands are read write - 4x symbol info, 2x sum write
-        self.assert_command_id(requests[0], constants.ADSCOMMAND_READWRITE)
-        self.assert_command_id(requests[1], constants.ADSCOMMAND_READWRITE)
-        self.assert_command_id(requests[2], constants.ADSCOMMAND_READWRITE)
-        self.assert_command_id(requests[3], constants.ADSCOMMAND_READWRITE)
-        self.assert_command_id(requests[4], constants.ADSCOMMAND_READWRITE)
-        self.assert_command_id(requests[5], constants.ADSCOMMAND_READWRITE)
-
-        # Expected result
-        expected_result = {
-            "TestVar1": "no error",
-            "TestVar2": "no error",
-            "str_TestVar3": "no error",
-            "TestVar4": "no error",
-        }
-        self.assertEqual(errors, expected_result)
-
-    def test_write_list_ads_sub_commands(self):
-        variables = {
-            "TestVar1": 1,
-            "TestVar2": 2,
-            "str_TestVar3": "test",
-            "TestVar4": 3,
-        }
-
-        with self.plc:
-            errors = self.plc.write_list_by_name(variables, ads_sub_commands=2)
-
-        # Retrieve list of received requests from server
-        requests = self.test_server.request_history
-
-        # Assert that the server received 6 requests - 4x symbol info, 2x write as split by subcommands
-        self.assertEqual(len(requests), 6)
-
-        # Assert that all commands are read write - 4x symbol info, 2x sum write
+        # Assert that all commands are read write
         self.assert_command_id(requests[0], constants.ADSCOMMAND_READWRITE)
         self.assert_command_id(requests[1], constants.ADSCOMMAND_READWRITE)
         self.assert_command_id(requests[2], constants.ADSCOMMAND_READWRITE)


### PR DESCRIPTION
removed some duplicate tests. read/write_list_sub_commands had their tests duplicaed, possibly casused by merge of last PR. Also added more test crtieria for the no cache tests  on rad and write_list_by_name to make sure that the symbol is not cached.