### PR TITLE
Added PLCTYPE_* as the prefered type of symbol initialization

### DIFF
--- a/doc/documentation/symbols.rst
+++ b/doc/documentation/symbols.rst
@@ -28,10 +28,11 @@ provided:
    >>> symbol = plc.get_symbol('global.bool_value')
    # Alternatively, specify all information and no lookup will be done:
    >>> symbol = plc.get_symbol('global.bool_value', index_group=123,
-                               index_offset=12345, symbol_type='BOOL')
+                               index_offset=12345, symbol_type=pyads.PLCTYPE_BOOL)
 
 Here the indices are same as used in :py:meth:`.Connection.read` and :py:meth:`.Connection.write`.
-The symbol type is a string of the variable type in PLC-style, e.g. ‘LREAL’, ‘INT’, ‘UDINT’, etc.
+The symbol type can also be the same as with the read and write method, e.g. ``pyads.PLCTYPE_INT`` or ``pyads.PLCTYPE_BOOL``.
+Alternatively, the class will also accept a string of the variable type in PLC-style, e.g. ‘LREAL’, ‘INT’, ‘UDINT’, etc.
 
 .. warning::
 

--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -710,7 +710,7 @@ class Connection(object):
         name: Optional[str] = None,
         index_group: Optional[int] = None,
         index_offset: Optional[int] = None,
-        symbol_type: Optional[str] = None,
+        symbol_type: Optional[Union[str, Type]] = None,
         comment: Optional[str] = None,
         auto_update: bool = False,
     ) -> AdsSymbol:
@@ -720,13 +720,15 @@ class Connection(object):
         index_offset so the symbol can be located.
         If the name was specified but not all other attributes were,
         the other attributes will be looked up from the connection.
-        `symbol_type` should be a string representing a PLC type (e.g.
+
+        `symbol_type` should be a type constant like `pyads.PLCTYPE_*`.
+        Alternatively, it can be a string representation a PLC type (e.g.
         'LREAL').
 
         :param name:
         :param index_group:
         :param index_offset:
-        :param symbol_type: PLC variable type (e.g. 'LREAL')
+        :param symbol_type: PLC variable type (e.g. `pyads.PLCTYPE_DINT`)
         :param comment:
         :param auto_update: Create notification to update buffer (same as
             `set_auto_update(True)`)

--- a/pyads/symbol.py
+++ b/pyads/symbol.py
@@ -12,7 +12,7 @@ the circular dependencies.
 
 import re
 from ctypes import sizeof
-from typing import TYPE_CHECKING, Any, Optional, List, Tuple, Callable
+from typing import TYPE_CHECKING, Any, Optional, List, Tuple, Callable, Union, Type
 
 from . import constants  # To access all constants, use package notation
 from .pyads_ex import adsGetSymbolInfo
@@ -58,24 +58,26 @@ class AdsSymbol:
         name: Optional[str] = None,
         index_group: Optional[int] = None,
         index_offset: Optional[int] = None,
-        symbol_type: Optional[str] = None,
+        symbol_type: Optional[Union[str, Type]] = None,
         comment: Optional[str] = None,
         auto_update: bool = False,
     ) -> None:
-        """Create AdsSymbol instance
+        """Create AdsSymbol instance.
 
         Specify either the variable name or the index_group **and**
         index_offset so the symbol can be located.
         If the name was specified but not all other attributes were,
         the other attributes will be looked up from the connection.
-        `symbol_type` should be a string representing a PLC type (e.g.
+
+        `symbol_type` should be a type constant like `pyads.PLCTYPE_*`.
+        Alternatively, it can be a string representation a PLC type (e.g.
         'LREAL').
 
         :param plc: Connection instance
         :param name:
         :param index_group:
         :param index_offset:
-        :param symbol_type: PLC variable type (e.g. 'LREAL')
+        :param symbol_type: PLC variable type (e.g. `pyads.PLCTYPE_DINT`)
         :param comment:
         :param auto_update: Create notification to update buffer (same as
             `set_auto_update(True)`)
@@ -112,7 +114,10 @@ class AdsSymbol:
 
         self.plc_type: Optional[Any] = None
         if self.symbol_type is not None:
-            self.plc_type = AdsSymbol.get_type_from_str(self.symbol_type)
+            if isinstance(self.symbol_type, str):  # Perform lookup if string
+                self.plc_type = AdsSymbol.get_type_from_str(self.symbol_type)
+            else:  # Otherwise `symbol_type` is probably a pyads.PLCTYPE_* constant
+                self.plc_type = self.symbol_type
 
         self.auto_update = auto_update
 

--- a/tests/test_symbol.py
+++ b/tests/test_symbol.py
@@ -58,6 +58,7 @@ class AdsSymbolTestCase(unittest.TestCase):
             "TestDouble", ads_type=constants.ADST_REAL64, symbol_type="LREAL"
         )
         self.test_var.comment = "Some variable of type double"
+        self.test_var_type = pyads.constants.PLCTYPE_LREAL  # Corresponds with "LREAL"
         self.handler.add_variable(self.test_var)
 
         self.plc = pyads.Connection(
@@ -153,7 +154,7 @@ class AdsSymbolTestCase(unittest.TestCase):
             name=var.name,
             index_group=var.index_group,
             index_offset=var.index_offset,
-            symbol_type=var.symbol_type,
+            symbol_type=var.symbol_type,  # String initialization
         )  # No lookup
 
         # Verify looked up info
@@ -205,6 +206,12 @@ class AdsSymbolTestCase(unittest.TestCase):
         """Test if PLCTYPE is resolved correctly"""
         with self.plc:
 
+            symbol_const = AdsSymbol(self.plc, "NonExistentVar", 123, 0,
+                                     pyads.PLCTYPE_UDINT)
+            self.assertEqual(constants.PLCTYPE_UDINT, symbol_const.plc_type)
+            self.assertNotIsInstance(symbol_const.symbol_type, str)  # symbol_type
+            # can't a neat human-readable string now
+
             symbol_str = AdsSymbol(self.plc, "NonExistentVar", 123, 0, "UDINT")
             self.assertEqual(constants.PLCTYPE_UDINT, symbol_str.plc_type)
             self.assertEqual("UDINT", symbol_str.symbol_type)
@@ -226,7 +233,7 @@ class AdsSymbolTestCase(unittest.TestCase):
                 name=self.test_var.name,
                 index_group=self.test_var.index_group,
                 index_offset=self.test_var.index_offset,
-                symbol_type=self.test_var.symbol_type,
+                symbol_type=self.test_var_type,
             )
 
             self.assertAdsRequestsCount(0)  # No requests yet


### PR DESCRIPTION
Title says it all. Should solve #201 .

Two questions:

- What is the correct type hint for a ctypes class, like the `pyads.PLCTYPE_*` constants?
- Should be also modify `Connection.read` and `.write` to accept the same arguments as `get_symbol`, i.e. both a ctypes class and string?