### PR TITLE
Add datatype annotations

### DIFF
--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -613,7 +613,7 @@ class Connection(object):
         return None
 
     def write(
-        self, index_group: int, index_offset: int, value: Any, plc_datatype: Type[PLCDataType]
+        self, index_group: int, index_offset: int, value: Any, plc_datatype: Type["PLCDataType"]
     ) -> None:
         """Send data synchronous to an ADS-device.
 
@@ -621,7 +621,7 @@ class Connection(object):
             constants
         :param int index_offset: PLC storage address
         :param Any value: value to write to the storage address of the PLC
-        :param Type[PLCDataType] plc_datatype: type of the data given to the PLC,
+        :param Type["PLCDataType"] plc_datatype: type of the data given to the PLC,
             according to PLCTYPE constants
 
         """
@@ -634,9 +634,9 @@ class Connection(object):
         self,
         index_group: int,
         index_offset: int,
-        plc_read_datatype: Optional[Type[PLCDataType]],
+        plc_read_datatype: Optional[Type["PLCDataType"]],
         value: Any,
-        plc_write_datatype: Optional[Type[PLCDataType]],
+        plc_write_datatype: Optional[Type["PLCDataType"]],
         return_ctypes: bool = False,
         check_length: bool = True,
     ) -> Any:
@@ -645,10 +645,10 @@ class Connection(object):
         :param int index_group: PLC storage area, according to the INDEXGROUP
             constants
         :param int index_offset: PLC storage address
-        :param Type[PLCDataType] plc_read_datatype: type of the data given to the PLC to respond to,
+        :param Type["PLCDataType"] plc_read_datatype: type of the data given to the PLC to respond to,
             according to PLCTYPE constants, or None to not read anything
         :param value: value to write to the storage address of the PLC
-        :param Type[PLCDataType] plc_write_datatype: type of the data given to the PLC, according to
+        :param Type["PLCDataType"] plc_write_datatype: type of the data given to the PLC, according to
             PLCTYPE constants, or None to not write anything
         :param bool return_ctypes: return ctypes instead of python types if True
         (default: False)
@@ -676,7 +676,7 @@ class Connection(object):
         self,
         index_group: int,
         index_offset: int,
-        plc_datatype: Type[PLCDataType],
+        plc_datatype: Type["PLCDataType"],
         return_ctypes: bool = False,
         check_length: bool = True,
     ) -> Any:
@@ -685,7 +685,7 @@ class Connection(object):
         :param int index_group: PLC storage area, according to the INDEXGROUP
             constants
         :param int index_offset: PLC storage address
-        :param Type[PLCDataType] plc_datatype: type of the data given to the PLC, according
+        :param Type["PLCDataType"] plc_datatype: type of the data given to the PLC, according
             to PLCTYPE constants
         :param bool return_ctypes: return ctypes instead of python types if True
             (default: False)
@@ -712,7 +712,7 @@ class Connection(object):
         name: Optional[str] = None,
         index_group: Optional[int] = None,
         index_offset: Optional[int] = None,
-        plc_datatype: Optional[Union[Type[PLCDataType], str]] = None,
+        plc_datatype: Optional[Union[Type["PLCDataType"], str]] = None,
         comment: Optional[str] = None,
         auto_update: bool = False,
     ) -> AdsSymbol:
@@ -728,7 +728,7 @@ class Connection(object):
         :param str name:
         :param Optional[int] index_group:
         :param Optional[int] index_offset:
-        :param Optional[Union[Type[PLCDataType], str]]: type of the  PLC variable, according
+        :param Optional[Union[Type["PLCDataType"], str]]: type of the  PLC variable, according
             to PLCTYPE constants
         :param str comment: comment
         :param bool auto_update: Create notification to update buffer (same as
@@ -816,7 +816,7 @@ class Connection(object):
     def read_by_name(
         self,
         data_name: str,
-        plc_datatype: Optional[Type[PLCDataType]] = None,
+        plc_datatype: Optional[Type["PLCDataType"]] = None,
         return_ctypes: bool = False,
         handle: Optional[int] = None,
         check_length: bool = True,
@@ -825,7 +825,7 @@ class Connection(object):
         """Read data synchronous from an ADS-device from data name.
 
         :param string data_name: data name,  can be empty string if handle is used
-        :param Optional[Type[PLCDataType]] plc_datatype: type of the data given to the PLC, according
+        :param Optional[Type["PLCDataType"]] plc_datatype: type of the data given to the PLC, according
             to PLCTYPE constants, if None the datatype will be read from the target
             with adsGetSymbolInfo (default: None)
         :param bool return_ctypes: return ctypes instead of python types if True
@@ -1021,7 +1021,7 @@ class Connection(object):
         self,
         data_name: str,
         value: Any,
-        plc_datatype: Optional[Type[PLCDataType]] = None,
+        plc_datatype: Optional[Type["PLCDataType"]] = None,
         handle: Optional[int] = None,
         cache_symbol_info: bool = True,
     ) -> None:

--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -728,7 +728,7 @@ class Connection(object):
         :param str name:
         :param Optional[int] index_group:
         :param Optional[int] index_offset:
-        :param Optional[Union[Type["PLCDataType"], str]]: type of the  PLC variable, according
+        :param plc_datatype: type of the  PLC variable, according
             to PLCTYPE constants
         :param str comment: comment
         :param bool auto_update: Create notification to update buffer (same as

--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -613,15 +613,15 @@ class Connection(object):
         return None
 
     def write(
-        self, index_group: int, index_offset: int, value: Any, plc_datatype: Type
+        self, index_group: int, index_offset: int, value: Any, plc_datatype: Type[PLCDataType]
     ) -> None:
         """Send data synchronous to an ADS-device.
 
         :param int index_group: PLC storage area, according to the INDEXGROUP
             constants
         :param int index_offset: PLC storage address
-        :param value: value to write to the storage address of the PLC
-        :param int plc_datatype: type of the data given to the PLC,
+        :param Any value: value to write to the storage address of the PLC
+        :param Type[PLCDataType] plc_datatype: type of the data given to the PLC,
             according to PLCTYPE constants
 
         """
@@ -634,9 +634,9 @@ class Connection(object):
         self,
         index_group: int,
         index_offset: int,
-        plc_read_datatype: Optional[Type],
+        plc_read_datatype: Optional[Type[PLCDataType]],
         value: Any,
-        plc_write_datatype: Optional[Type],
+        plc_write_datatype: Optional[Type[PLCDataType]],
         return_ctypes: bool = False,
         check_length: bool = True,
     ) -> Any:
@@ -645,10 +645,10 @@ class Connection(object):
         :param int index_group: PLC storage area, according to the INDEXGROUP
             constants
         :param int index_offset: PLC storage address
-        :param Type plc_read_datatype: type of the data given to the PLC to respond to,
+        :param Type[PLCDataType] plc_read_datatype: type of the data given to the PLC to respond to,
             according to PLCTYPE constants, or None to not read anything
         :param value: value to write to the storage address of the PLC
-        :param Type plc_write_datatype: type of the data given to the PLC, according to
+        :param Type[PLCDataType] plc_write_datatype: type of the data given to the PLC, according to
             PLCTYPE constants, or None to not write anything
         :param bool return_ctypes: return ctypes instead of python types if True
         (default: False)
@@ -676,7 +676,7 @@ class Connection(object):
         self,
         index_group: int,
         index_offset: int,
-        plc_datatype: Type,
+        plc_datatype: Type[PLCDataType],
         return_ctypes: bool = False,
         check_length: bool = True,
     ) -> Any:
@@ -685,7 +685,7 @@ class Connection(object):
         :param int index_group: PLC storage area, according to the INDEXGROUP
             constants
         :param int index_offset: PLC storage address
-        :param int plc_datatype: type of the data given to the PLC, according
+        :param Type[PLCDataType] plc_datatype: type of the data given to the PLC, according
             to PLCTYPE constants
             :return: value: **value**
         :param bool return_ctypes: return ctypes instead of python types if True
@@ -815,7 +815,7 @@ class Connection(object):
     def read_by_name(
         self,
         data_name: str,
-        plc_datatype: Optional[Type] = None,
+        plc_datatype: Optional[Type[PLCDataType]] = None,
         return_ctypes: bool = False,
         handle: Optional[int] = None,
         check_length: bool = True,
@@ -824,7 +824,7 @@ class Connection(object):
         """Read data synchronous from an ADS-device from data name.
 
         :param string data_name: data name,  can be empty string if handle is used
-        :param int plc_datatype: type of the data given to the PLC, according
+        :param Optional[Type[PLCDataType]] plc_datatype: type of the data given to the PLC, according
             to PLCTYPE constants, if None the datatype will be read from the target
             with adsGetSymbolInfo (default: None)
         :param bool return_ctypes: return ctypes instead of python types if True
@@ -1020,7 +1020,7 @@ class Connection(object):
         self,
         data_name: str,
         value: Any,
-        plc_datatype: Optional[Type] = None,
+        plc_datatype: Optional[Type[PLCDataType]] = None,
         handle: Optional[int] = None,
         cache_symbol_info: bool = True,
     ) -> None:

--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -712,7 +712,7 @@ class Connection(object):
         name: Optional[str] = None,
         index_group: Optional[int] = None,
         index_offset: Optional[int] = None,
-        data_type: Optional[Union[Type[PLCDataType], str]] = None,
+        plc_datatype: Optional[Union[Type[PLCDataType], str]] = None,
         comment: Optional[str] = None,
         auto_update: bool = False,
     ) -> AdsSymbol:
@@ -735,7 +735,7 @@ class Connection(object):
             `set_auto_update(True)`)
         """
 
-        return AdsSymbol(self, name, index_group, index_offset, data_type,
+        return AdsSymbol(self, name, index_group, index_offset, plc_datatype,
                          comment, auto_update=auto_update)
 
     def get_all_symbols(self) -> List[AdsSymbol]:

--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -49,6 +49,8 @@ from .constants import (
     ADSIGRP_SUMUP_WRITE,
     MAX_ADS_SUB_COMMANDS,
     ads_type_to_ctype,
+    PLCSimpleDataType,
+    PLCDataType,
 )
 from .filetimes import filetime_to_dt
 from .pyads_ex import (

--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -687,11 +687,11 @@ class Connection(object):
         :param int index_offset: PLC storage address
         :param Type[PLCDataType] plc_datatype: type of the data given to the PLC, according
             to PLCTYPE constants
-            :return: value: **value**
         :param bool return_ctypes: return ctypes instead of python types if True
             (default: False)
         :param bool check_length: check whether the amount of bytes read matches the size
             of the read data type (default: True)
+        :return: value
 
         """
         if self._port is not None:
@@ -712,7 +712,7 @@ class Connection(object):
         name: Optional[str] = None,
         index_group: Optional[int] = None,
         index_offset: Optional[int] = None,
-        symbol_type: Optional[str] = None,
+        data_type: Optional[Union[Type[PLCDataType], str]] = None,
         comment: Optional[str] = None,
         auto_update: bool = False,
     ) -> AdsSymbol:
@@ -722,19 +722,20 @@ class Connection(object):
         index_offset so the symbol can be located.
         If the name was specified but not all other attributes were,
         the other attributes will be looked up from the connection.
-        `symbol_type` should be a string representing a PLC type (e.g.
-        'LREAL').
+        `data_type` should can be a PLCTYPE constant or  a string representing
+        a PLC type (e.g. 'LREAL').
 
-        :param name:
-        :param index_group:
-        :param index_offset:
-        :param symbol_type: PLC variable type (e.g. 'LREAL')
-        :param comment:
-        :param auto_update: Create notification to update buffer (same as
+        :param str name:
+        :param Optional[int] index_group:
+        :param Optional[int] index_offset:
+        :param Optional[Union[Type[PLCDataType], str]]: type of the  PLC variable, according
+            to PLCTYPE constants
+        :param str comment: comment
+        :param bool auto_update: Create notification to update buffer (same as
             `set_auto_update(True)`)
         """
 
-        return AdsSymbol(self, name, index_group, index_offset, symbol_type,
+        return AdsSymbol(self, name, index_group, index_offset, data_type,
                          comment, auto_update=auto_update)
 
     def get_all_symbols(self) -> List[AdsSymbol]:

--- a/pyads/constants.py
+++ b/pyads/constants.py
@@ -6,7 +6,7 @@
 :created on 2018-06-11 18:15:53
 
 """
-from typing import Type, Dict, Callable
+from typing import Type, Dict, Callable, Union
 from ctypes import (
     Array,
     c_bool,
@@ -52,6 +52,32 @@ PLCTYPE_DATE = PLCTYPE_DWORD
 PLCTYPE_DATE_AND_TIME = PLCTYPE_DWORD
 PLCTYPE_DT = PLCTYPE_DWORD
 PLCTYPE_TIME = PLCTYPE_DWORD
+
+# Typing
+PLCSimpleDataType = Union[
+    PLCTYPE_BOOL,
+    PLCTYPE_BYTE,
+    PLCTYPE_DWORD,
+    PLCTYPE_DINT,
+    PLCTYPE_INT,
+    PLCTYPE_LREAL,
+    PLCTYPE_REAL,
+    PLCTYPE_SINT,
+    PLCTYPE_STRING,
+    PLCTYPE_TOD,
+    PLCTYPE_UBYTE,
+    PLCTYPE_UDINT,
+    PLCTYPE_UINT,
+    PLCTYPE_USINT,
+    PLCTYPE_WORD,
+    PLCTYPE_LINT,
+    PLCTYPE_ULINT,
+    PLCTYPE_DATE,
+    PLCTYPE_DATE_AND_TIME,
+    PLCTYPE_DT,
+    PLCTYPE_TIME,
+]
+PLCDataType = Union[Array, PLCSimpleDataType]
 
 # Datatype unpacking values
 DATATYPE_MAP: Dict[Type, str] = {

--- a/test.py
+++ b/test.py
@@ -1,0 +1,10 @@
+import pyads
+from pyads.ads import PLCDataType, PLCSimpleDataType
+from ctypes import Array, c_uint8
+from typing import Union, Type
+
+
+def test(datatype: Type[Union[Array, "PLCSimpleDataType"]]) -> None:
+    return None
+
+test(str)


### PR DESCRIPTION
This PR introduces PLCSimpleDataType and PLCDataType to make type-annotations more specific. 

Also it renames the symbol_type parameter of Connection.get_symbol to plc_datatype to fit in the pattern of functions like read or read_by_name. I hope @RobertoRoos doesn't mind this small change.