### PR TITLE
Make the AdvancedHandler less magical

### DIFF
--- a/pyads/testserver.py
+++ b/pyads/testserver.py
@@ -550,7 +550,7 @@ class PLCVariable:
 
     def __init__(self,
                  name: str,
-                 value: bytes,
+                 value: Union[int, float, bytes],
                  ads_type: int,
                  symbol_type: str,
                  index_group: Optional[int] = None,
@@ -567,7 +567,15 @@ class PLCVariable:
         :param Optional[int] index_offset: set index_offset manually
         """
         self.name = name.strip('\x00')
-        self.value = value  # value is stored in binary!
+
+        # value is stored in binary!
+        if isinstance(value, bytes):
+            self.value = value
+        else:
+            # try to pack value according to ads_type
+            fmt = constants.DATATYPE_MAP[constants.ads_type_to_ctype[ads_type]]
+            self.value = struct.pack(fmt, value)
+
         self.ads_type = ads_type
         self.symbol_type = symbol_type
 

--- a/pyads/testserver.py
+++ b/pyads/testserver.py
@@ -571,17 +571,16 @@ class PLCVariable:
 
         self.set_type(ads_type, symbol_type)
 
-        self.handle = self.handle_count
-        self.index_group = self.INDEX_GROUP  # Default value - shouldn't
-        # matter much
-        self.index_offset = self.INDEX_OFFSET_BASE + self.handle  # We will
+        self.handle = PLCVariable.handle_count
+        self.index_group = PLCVariable.INDEX_GROUP  # default value - shouldn't matter much
+        self.index_offset = PLCVariable.INDEX_OFFSET_BASE + self.handle  # We will
         # cheat by using the handle (since we know it will be unique)
 
         self.comment: str = ''
 
         self.size = 2  # Value size in bytes
 
-        self.handle_count += 1  # Increment class property
+        PLCVariable.handle_count += 1  # Increment class property
 
     def set_type(self, ads_type: int, symbol_type: str) -> None:
         """Set a new ADST_ variable type (also update PLCTYPE_

--- a/pyads/testserver.py
+++ b/pyads/testserver.py
@@ -738,7 +738,7 @@ class AdvancedHandler(AbstractHandler):
                 var.value = value
                 return b""
 
-            var = self.get_or_create_variable_by_indices(
+            var = self.get_variable_by_indices(
                 index_group, index_offset)
             var.value = value
 
@@ -774,7 +774,7 @@ class AdvancedHandler(AbstractHandler):
 
                 # This could be part of a write-by-name, so create the
                 # variable if it does not yet exist
-                var = self.get_or_create_variable_by_name(var_name)
+                var = self.get_variable_by_name(var_name)
 
                 read_data = struct.pack("<I", var.handle)
 
@@ -879,17 +879,6 @@ class AdvancedHandler(AbstractHandler):
                        'it first explicitly or write to it'
                        .format(index_group, index_offset))
 
-    def get_or_create_variable_by_indices(self, index_group: int, index_offset: int) -> PLCVariable:
-        """Try to retrieve a variable by indices, create it if non-existent"""
-        try:
-            return self.get_variable_by_indices(index_group, index_offset)
-        except KeyError:
-            var = PLCVariable()
-            var.index_group = index_group
-            var.index_offset = index_offset
-            self.add_variable(var)
-            return var
-
     def get_variable_by_name(self, name: str) -> PLCVariable:
         """Get variable by name, throw error if not found"""
         name = name.strip('\x00')
@@ -898,15 +887,6 @@ class AdvancedHandler(AbstractHandler):
                 return var
         raise KeyError('Variable with name `{}` not found - Create it first '
                        'explicitly or write to it'.format(name))
-
-    def get_or_create_variable_by_name(self, name: str) -> PLCVariable:
-        """Try to retrieve a variable by indices, create it if non-existent"""
-        try:
-            return self.get_variable_by_name(name)
-        except KeyError:
-            var = PLCVariable(name=name)
-            self.add_variable(var)
-            return var
 
     def add_variable(self, var: PLCVariable) -> None:
         tup = (var.index_group, var.index_offset)

--- a/tests/test_connection_class.py
+++ b/tests/test_connection_class.py
@@ -1323,7 +1323,9 @@ class AdsApiTestCaseAdvanced(unittest.TestCase):
     def test_read_check_length(self):
         # Write data shorter than what should be read
         self.handler.add_variable(
-            PLCVariable("i", 1, constants.PLCTYPE_USINT, index_group=constants.INDEXGROUP_DATA, index_offset=1))
+            PLCVariable("i", 1, constants.ADST_UINT8, symbol_type="USINT",
+                        index_group=constants.INDEXGROUP_DATA,
+                        index_offset=1))
         with self.plc:
             with self.assertRaises(RuntimeError):
                 # Since the length is checked, this must give an error
@@ -1348,7 +1350,8 @@ class AdsApiTestCaseAdvanced(unittest.TestCase):
             self.assertEqual(len(self.plc.get_all_symbols()), 0)
 
     def test_get_all_symbols_single(self):
-        self.handler.add_variable(PLCVariable("i", 1, constants.PLCTYPE_INT, index_group=123, index_offset=0))
+        self.handler.add_variable(
+            PLCVariable("i", 1, constants.ADST_INT16, symbol_type="INT", index_group=123, index_offset=0))
         with self.plc:
             symbols = self.plc.get_all_symbols()
             self.assertEqual(len(symbols), 1)
@@ -1356,8 +1359,8 @@ class AdsApiTestCaseAdvanced(unittest.TestCase):
 
     def test_read_by_name_without_datatype(self) -> None:
         """Test read by name without passing the datatype."""
-        # creat variable on testserver
-        self.handler.add_variable(PLCVariable("test_var", 42, pyads.PLCTYPE_INT))
+        # create variable on testserver
+        self.handler.add_variable(PLCVariable("test_var", 42, constants.ADST_INT16, "INT"))
         with self.plc:
             # read twice to show caching
             read_value = self.plc.read_by_name("test_var")
@@ -1372,7 +1375,7 @@ class AdsApiTestCaseAdvanced(unittest.TestCase):
     def test_write_by_name_without_datatype(self) -> None:
         """Test read by name without passing the datatype."""
         # create variable on testserver
-        self.handler.add_variable(PLCVariable("test_var", 0, pyads.PLCTYPE_INT))
+        self.handler.add_variable(PLCVariable("test_var", 0, constants.ADST_INT16, "INT"))
         with self.plc:
             # write twice to show caching
             self.plc.write_by_name("test_var", 42)

--- a/tests/test_connection_class.py
+++ b/tests/test_connection_class.py
@@ -18,7 +18,6 @@ from pyads.structs import NotificationAttrib
 from pyads import constants, structs
 from collections import OrderedDict
 
-
 # These are pretty arbitrary
 TEST_SERVER_AMS_NET_ID = "127.0.0.1.1.1"
 TEST_SERVER_IP_ADDRESS = "127.0.0.1"
@@ -1321,17 +1320,11 @@ class AdsApiTestCaseAdvanced(unittest.TestCase):
             TEST_SERVER_AMS_NET_ID, TEST_SERVER_AMS_PORT, TEST_SERVER_IP_ADDRESS
         )
 
-
     def test_read_check_length(self):
         # Write data shorter than what should be read
+        self.handler.add_variable(
+            PLCVariable("i", 1, constants.PLCTYPE_USINT, index_group=constants.INDEXGROUP_DATA, index_offset=1))
         with self.plc:
-            self.plc.write(
-                value=1,
-                index_group=constants.INDEXGROUP_DATA,
-                index_offset=1,
-                plc_datatype=constants.PLCTYPE_USINT,
-            )
-
             with self.assertRaises(RuntimeError):
                 # Since the length is checked, this must give an error
                 self.plc.read(
@@ -1355,23 +1348,17 @@ class AdsApiTestCaseAdvanced(unittest.TestCase):
             self.assertEqual(len(self.plc.get_all_symbols()), 0)
 
     def test_get_all_symbols_single(self):
+        self.handler.add_variable(PLCVariable("i", 1, constants.PLCTYPE_INT, index_group=123, index_offset=0))
         with self.plc:
-            self.plc.write(
-                value="1",
-                index_group=123,
-                index_offset=0,
-                plc_datatype=constants.PLCTYPE_STRING
-            )
             symbols = self.plc.get_all_symbols()
             self.assertEqual(len(symbols), 1)
             self.assertEqual(symbols[0].index_group, 123)
 
     def test_read_by_name_without_datatype(self) -> None:
         """Test read by name without passing the datatype."""
+        # creat variable on testserver
+        self.handler.add_variable(PLCVariable("test_var", 42, pyads.PLCTYPE_INT))
         with self.plc:
-            # create variable on testserver
-            self.plc.write_by_name("test_var", 42, pyads.PLCTYPE_INT)
-
             # read twice to show caching
             read_value = self.plc.read_by_name("test_var")
             read_value2 = self.plc.read_by_name("test_var")
@@ -1384,9 +1371,9 @@ class AdsApiTestCaseAdvanced(unittest.TestCase):
 
     def test_write_by_name_without_datatype(self) -> None:
         """Test read by name without passing the datatype."""
+        # create variable on testserver
+        self.handler.add_variable(PLCVariable("test_var", 0, pyads.PLCTYPE_INT))
         with self.plc:
-            # create variable on testserver
-            self.plc.write_by_name("test_var", 0, pyads.PLCTYPE_INT)
             # write twice to show caching
             self.plc.write_by_name("test_var", 42)
             self.plc.write_by_name("test_var", 42)
@@ -1397,6 +1384,7 @@ class AdsApiTestCaseAdvanced(unittest.TestCase):
             self.plc.write_by_name("test_var", 43, cache_symbol_info=False)
             read_value = self.plc.read_by_name("test_var")
             self.assertEqual(read_value, 43)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR removes some of the magic from the AdvancedHandler of the AdsTestserver. Namely this is:

1. PLCVariables will need to be added to the handler before they can be written to or read from
This gives more control over the creation process and makes it more explicit.

2. PLCVariables need name, value, ads_type and symbol_type on initialisation. 
This mirrors more the situation we have with a real plc where we create variables upfront with all necessary type informations at hand. Also it brings more clarity in the tests. One can see which values and types are used by simply looking at the test. No need to search for the default values.