### PR TITLE
Support structured data types in write_list_by_name

### DIFF
--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -915,6 +915,7 @@ class Connection(object):
         data_names_and_values: Dict[str, Any],
         cache_symbol_info: bool = True,
         ads_sub_commands: int = MAX_ADS_SUB_COMMANDS,
+        structure_defs: Optional[Dict[str, StructureDef]] = None,
     ) -> Dict[str, ADSError]:
         """Write a list of variables.
 
@@ -928,6 +929,9 @@ class Connection(object):
         :param bool cache_symbol_info: when True, symbol info will be cached for future reading
         :param int ads_sub_commands: Max number of ADS-Sub commands used to write the variables in a single ADS call.
             A larger number can be used but may jitter the PLC execution!
+        :param dict structure_defs: for structured variables, optional mapping of
+            data name to special tuple defining the structure and
+            types contained within it according to PLCTYPE constants
 
         :return adsSumWrite: A dictionary containing variable names from data_names as keys and values return codes for each write operation from the PLC
         :rtype dict(str, ADSError)
@@ -952,9 +956,15 @@ class Connection(object):
                 for i in data_names_and_values.keys()
             }
 
+        for name, structure_def in structure_defs.items():
+            data_names_and_values[name] = bytes_from_dict(
+                data_names_and_values[name], structure_def)
+
+        structured_data_names = list(structure_defs.keys())
         if len(data_names_and_values) <= ads_sub_commands:
             return adsSumWrite(
-                self._port, self._adr, data_names_and_values, data_symbols
+                self._port, self._adr, data_names_and_values, data_symbols,
+                structured_data_names
             )
 
         return_data: Dict[str, ADSError] = {}
@@ -962,7 +972,8 @@ class Connection(object):
             data_names_and_values, ads_sub_commands
         ):
             return_data.update(
-                adsSumWrite(self._port, self._adr, data_names_slice, data_symbols)
+                adsSumWrite(self._port, self._adr, data_names_slice,
+                            data_symbols, structured_data_names)
             )
         return return_data
 

--- a/pyads/pyads_ex.py
+++ b/pyads/pyads_ex.py
@@ -925,6 +925,7 @@ def adsSumWrite(
     address: AmsAddr,
     data_names_and_values: Dict[str, Any],
     data_symbols: Dict[str, SAdsSymbolEntry],
+    structured_data_names: List[str],
 ) -> Dict[str, ADSError]:
     """Perform a sum write to write the value of multiple ADS variables
 
@@ -934,6 +935,7 @@ def adsSumWrite(
     :type data_names_and_values: dict[str, Any]
     :param data_symbols: list of dictionaries of ADS Symbol Info
     :type data_symbols: dict[str, ADSSymbolInfo]
+    :param structured_data_names: list of structured variable names
     :return: result: dict of variable names and error codes
     :rtype: dict[str, ADSError]
     """
@@ -953,7 +955,9 @@ def adsSumWrite(
         offset += 12
 
     for data_name, value in data_names_and_values.items():
-        if (
+        if data_name in structured_data_names:
+            buf[offset : offset + data_symbols[data_name].size] = value
+        elif (
             data_symbols[data_name].dataType != ADST_STRING
             and data_symbols[data_name].dataType != ADST_WSTRING
         ):

--- a/tests/test_connection_class.py
+++ b/tests/test_connection_class.py
@@ -1194,6 +1194,33 @@ class AdsConnectionClassTestCase(unittest.TestCase):
         }
         self.assertEqual(actual_result, expected_result)
 
+    def test_write_structure_list(self):
+        variables = ["TestStructure", "TestVar"]
+        structure_defs = {"TestStructure": (("xVar", pyads.PLCTYPE_BYTE, 1),)}
+        # structure_defs = {}
+        data = {
+            "TestStructure": {"xVar": 11},
+            "TestVar": 22,
+        }
+
+        with self.plc:
+            errors = self.plc.write_list_by_name(data, cache_symbol_info=False,
+                                                 structure_defs=structure_defs)
+
+        requests = self.test_server.request_history
+        self.assertEqual(len(requests), 3)
+
+        # Assert that all commands are read write - 2x symbol info, 1x sum write
+        for request in requests:
+            self.assert_command_id(request, constants.ADSCOMMAND_READWRITE)
+
+        self.assertEqual(errors, {v: "no error" for v in variables})
+
+        with self.plc:
+            written_data = self.plc.read_list_by_name(variables, cache_symbol_info=False,
+                                                      structure_defs=structure_defs)
+        self.assertEqual(data, written_data)
+
     def test_write_list(self):
         variables = {
             "i1": 1,


### PR DESCRIPTION
> As follow-up to #187, I'd like to add support for structured types in write_list_by_name.
The implementation should be quite straightforward, yet the unit test fails when I try to verify the written data by reading it again. Or could it be a limitation of the testserver?