### PR TITLE
Add structure support to AdsSymbol class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## 3.3.5 [unreleased]
 
 ### Added
+* [#223](https://github.com/stlehmann/pyads/pull/223) Add structure support for symbols
 
 ### Changed
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -180,5 +180,5 @@ texinfo_documents = [
      'Miscellaneous'),
 ]
 
-
+autoclass_content = 'both'
 

--- a/doc/documentation/symbols.rst
+++ b/doc/documentation/symbols.rst
@@ -34,10 +34,19 @@ Here the indices are same as used in :py:meth:`.Connection.read` and :py:meth:`.
 The symbol type can also be the same as with the read and write method, e.g. ``pyads.PLCTYPE_INT`` or ``pyads.PLCTYPE_BOOL``.
 Alternatively, the class will also accept a string of the variable type in PLC-style, e.g. ‘LREAL’, ‘INT’, ‘UDINT’, etc.
 
-.. warning::
+Symbols also work with structures and arrays of structures. Use the parameter `structure_def` to define the structure
+and `array_size` to define the size of the array.
 
-  Symbols don't work with structs or lists of structs. But you can use them to address specific
-  members of a struct, e.g. `plc.get_symbol("GVL.mydata.ival")`.
+.. code:: python
+
+    >>> structure_def = (
+            ("i", pyads.PLCTYPE_INT, 1),
+            ("s", pyads.PLCTYPE_STRING, 1)
+        )
+    >>> symbol = plc.get_symbol("MyStructure", structure_def=structure_def, array_size=2)
+    >>> symbol.write([{"i": 1, " "s": "foo"}, {"i": 2, "s": "bar"}])
+    >>> symbol.read()
+   [{"i": 1, " "s": "foo"}, {"i": 2, "s": "bar"}]
 
 Read and write operations
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/mypy.ini
+++ b/mypy.ini
@@ -4,6 +4,7 @@ follow_imports = silent
 disallow_untyped_calls = true
 disallow_untyped_defs = true
 allow_redefinition = true
+strict_optional = false
 
 [mypy-pyads.testserver_ex.*]
 disallow_untyped_calls = false

--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -735,6 +735,27 @@ class Connection(object):
         :param str comment: comment
         :param bool auto_update: Create notification to update buffer (same as
             `set_auto_update(True)`)
+        :param Optional["StructureDef"] structure_def: special tuple defining the structure and
+            types contained within it according to PLCTYPE constants, must match
+            the structure defined in the PLC, PLC structure must be defined with
+            {attribute 'pack_mode' :=  '1'}
+
+        Expected input example for structure_def:
+
+        .. code:: python
+
+            structure_def = (
+                ('rVar', pyads.PLCTYPE_LREAL, 1),
+                ('sVar', pyads.PLCTYPE_STRING, 2, 35),
+                ('SVar1', pyads.PLCTYPE_STRING, 1),
+                ('rVar1', pyads.PLCTYPE_REAL, 1),
+                ('iVar', pyads.PLCTYPE_DINT, 1),
+                ('iVar1', pyads.PLCTYPE_INT, 3),
+            )
+
+            # i.e ('Variable Name', variable type, arr size (1 if not array),
+            # length of string (if defined in PLC))
+
         """
 
         return AdsSymbol(self, name, index_group, index_offset, plc_datatype,

--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -5,6 +5,7 @@
 :created on: 2018-06-11 18:15:53
 
 """
+from __future__ import annotations
 import struct
 import itertools
 from collections import OrderedDict

--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -717,6 +717,7 @@ class Connection(object):
         comment: Optional[str] = None,
         auto_update: bool = False,
         structure_def: Optional["StructureDef"] = None,
+        array_size: Optional[int] = 1,
     ) -> AdsSymbol:
         """Create a symbol instance
 
@@ -739,6 +740,7 @@ class Connection(object):
             types contained within it according to PLCTYPE constants, must match
             the structure defined in the PLC, PLC structure must be defined with
             {attribute 'pack_mode' :=  '1'}
+        :param Optional[int] array_size: size of array if reading array of structure, defaults to 1
 
         Expected input example for structure_def:
 
@@ -759,7 +761,7 @@ class Connection(object):
         """
 
         return AdsSymbol(self, name, index_group, index_offset, plc_datatype,
-                         comment, auto_update=auto_update, structure_def=structure_def)
+                         comment, auto_update=auto_update, structure_def=structure_def, array_size=array_size)
 
     def get_all_symbols(self) -> List[AdsSymbol]:
         """Read all symbols from an ADS-device.

--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -715,6 +715,7 @@ class Connection(object):
         plc_datatype: Optional[Union[Type["PLCDataType"], str]] = None,
         comment: Optional[str] = None,
         auto_update: bool = False,
+        structure_def: Optional["StructureDef"] = None,
     ) -> AdsSymbol:
         """Create a symbol instance
 
@@ -736,7 +737,7 @@ class Connection(object):
         """
 
         return AdsSymbol(self, name, index_group, index_offset, plc_datatype,
-                         comment, auto_update=auto_update)
+                         comment, auto_update=auto_update, structure_def=structure_def)
 
     def get_all_symbols(self) -> List[AdsSymbol]:
         """Read all symbols from an ADS-device.

--- a/pyads/symbol.py
+++ b/pyads/symbol.py
@@ -84,9 +84,27 @@ class AdsSymbol:
         :param comment:
         :param auto_update: Create notification to update buffer (same as
             `set_auto_update(True)`)
-        :param Optional[StructureDef] structure_def: tuple defining the structure and types contained within at
-            according to PLCTYPE constants, must match the structure defined in the PLC, PLC structure must be defined
-            with {attribute 'pack_mode' := '1'}
+        :param Optional["StructureDef"] structure_def: special tuple defining the structure and
+            types contained within it according to PLCTYPE constants, must match
+            the structure defined in the PLC, PLC structure must be defined with
+            {attribute 'pack_mode' :=  '1'}
+
+        Expected input example for structure_def:
+
+        .. code:: python
+
+            structure_def = (
+                ('rVar', pyads.PLCTYPE_LREAL, 1),
+                ('sVar', pyads.PLCTYPE_STRING, 2, 35),
+                ('SVar1', pyads.PLCTYPE_STRING, 1),
+                ('rVar1', pyads.PLCTYPE_REAL, 1),
+                ('iVar', pyads.PLCTYPE_DINT, 1),
+                ('iVar1', pyads.PLCTYPE_INT, 3),
+            )
+
+            # i.e ('Variable Name', variable type, arr size (1 if not array),
+            # length of string (if defined in PLC))
+
         """
         self._plc = plc
         self._handles_list: List[Tuple[int, int]] = []  # Notification handles

--- a/pyads/symbol.py
+++ b/pyads/symbol.py
@@ -9,6 +9,7 @@ the circular dependencies.
 :created on: 2020-11-16
 
 """
+from __future__ import annotations
 
 import re
 from ctypes import sizeof
@@ -59,7 +60,7 @@ class AdsSymbol:
             name: Optional[str] = None,
             index_group: Optional[int] = None,
             index_offset: Optional[int] = None,
-            symbol_type: Optional[Union[str, Type[PLCDataType]]] = None,
+            symbol_type: Optional[Union[str, Type["PLCDataType"]]] = None,
             comment: Optional[str] = None,
             auto_update: bool = False,
             structure_def: Optional["StructureDef"] = None,

--- a/pyads/symbol.py
+++ b/pyads/symbol.py
@@ -135,7 +135,7 @@ class AdsSymbol:
         self._structure_size = 0
         if self.structure_def is not None:
             from .ads import size_of_structure
-            self._structure_size = size_of_structure(self.structure_def)
+            self._structure_size = size_of_structure(self.structure_def * self.array_size)
 
         if missing_info:
             self._create_symbol_from_info()  # Perform remote lookup

--- a/pyads/symbol.py
+++ b/pyads/symbol.py
@@ -61,6 +61,7 @@ class AdsSymbol:
         symbol_type: Optional[Union[str, Type]] = None,
         comment: Optional[str] = None,
         auto_update: bool = False,
+        structure_def: Optional[StructureDef] = None,
     ) -> None:
         """Create AdsSymbol instance.
 
@@ -81,6 +82,9 @@ class AdsSymbol:
         :param comment:
         :param auto_update: Create notification to update buffer (same as
             `set_auto_update(True)`)
+        :param Optional[StructureDef] structure_def: tuple defining the structure and types contained within at
+            according to PLCTYPE constants, must match the structure defined in the PLC, PLC structure must be defined
+            with {attribute 'pack_mode' := '1'}
         """
         self._plc = plc
         self._handles_list: List[Tuple[int, int]] = []  # Notification handles

--- a/pyads/symbol.py
+++ b/pyads/symbol.py
@@ -64,6 +64,7 @@ class AdsSymbol:
             comment: Optional[str] = None,
             auto_update: bool = False,
             structure_def: Optional["StructureDef"] = None,
+            array_size: Optional[int] = 1,
     ) -> None:
         """Create AdsSymbol instance.
 
@@ -88,6 +89,7 @@ class AdsSymbol:
             types contained within it according to PLCTYPE constants, must match
             the structure defined in the PLC, PLC structure must be defined with
             {attribute 'pack_mode' :=  '1'}
+        :param Optional[int] array_size: size of array if reading array of structure, defaults to 1
 
         Expected input example for structure_def:
 
@@ -129,6 +131,7 @@ class AdsSymbol:
 
         # structure information
         self.structure_def = structure_def
+        self.array_size = array_size
         self._structure_size = 0
         if self.structure_def is not None:
             from .ads import size_of_structure
@@ -189,7 +192,8 @@ class AdsSymbol:
 
         if self.is_structure:
             self._value = self._plc.read_structure_by_name(self.name, self.structure_def,
-                                                           structure_size=self._structure_size)
+                                                           structure_size=self._structure_size,
+                                                           array_size=self.array_size)
         else:
             self._value = self._plc.read(self.index_group, self.index_offset, self.plc_type)
 
@@ -212,7 +216,7 @@ class AdsSymbol:
 
         if self.is_structure:
             self._plc.write_structure_by_name(self.name, new_value, self.structure_def,
-                                              structure_size=self._structure_size)
+                                              structure_size=self._structure_size, array_size=self.array_size)
         else:
             self._plc.write(self.index_group, self.index_offset, new_value, self.plc_type)
 

--- a/tests/test_symbol.py
+++ b/tests/test_symbol.py
@@ -12,7 +12,7 @@ from ctypes import sizeof, pointer
 import unittest
 import pyads
 from pyads.testserver import AdsTestServer, AdvancedHandler, PLCVariable
-from pyads import constants, AdsSymbol
+from pyads import constants, AdsSymbol, bytes_from_dict
 
 from tests.test_connection_class import create_notification_struct
 
@@ -312,6 +312,23 @@ class AdsSymbolTestCase(unittest.TestCase):
         self.assertAdsRequestsCount(3)  # WRITE, READWRITE for info and
         # final read
 
+    def test_read_structure(self):
+        """Test symbol value reading with structures."""
+        structure_def = (
+            ("i", pyads.PLCTYPE_INT, 1),
+            ("s", pyads.PLCTYPE_STRING, 1),
+        )
+        values = {"i": 1, "s": "foo"}
+        data = bytes(bytes_from_dict(values, structure_def))
+
+        self.handler.add_variable(PLCVariable("TestStructure", data, constants.ADST_VOID, symbol_type="TestStructure"))
+
+        with self.plc:
+            symbol = self.plc.get_symbol("TestStructure", structure_def=structure_def)
+            read_data = symbol.read()
+
+        self.assertEqual(values, read_data)
+
     def test_write(self):
         """Test symbol value writing"""
         with self.plc:
@@ -330,6 +347,25 @@ class AdsSymbolTestCase(unittest.TestCase):
 
         self.assertAdsRequestsCount(3)  # READWRITE for info, WRITE and
         # test read
+
+    def test_write_structure(self):
+        """Test symbol writing with structures."""
+        structure_def = (
+            ("i", pyads.PLCTYPE_INT, 1),
+            ("s", pyads.PLCTYPE_STRING, 1),
+        )
+        values = {"i": 1, "s": "foo"}
+        data = bytes(bytes_from_dict(values, structure_def))
+
+        self.handler.add_variable(PLCVariable("TestStructure", data, constants.ADST_VOID, symbol_type="TestStructure"))
+
+        write_values = {"i": 42, "s": "bar"}
+        with self.plc:
+            symbol = self.plc.get_symbol("TestStructure", structure_def=structure_def)
+            symbol.write(write_values)
+            read_values = symbol.read()
+
+        self.assertEqual(write_values, read_values)
 
     def test_value(self):
         """Test the buffer property"""

--- a/tests/test_symbol.py
+++ b/tests/test_symbol.py
@@ -334,8 +334,9 @@ class AdsSymbolTestCase(unittest.TestCase):
         structure_def = (
             ("a", pyads.PLCTYPE_INT, 1),
             ("b", pyads.PLCTYPE_INT, 1),
+            ("s", pyads.PLCTYPE_STRING, 1)
         )
-        values = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
+        values = [{"a": 1, "b": 2, "s": "foo"}, {"a": 3, "b": 4, "s": "bar"}]
         data = bytes(bytes_from_dict(values, structure_def))
 
         self.handler.add_variable(
@@ -390,14 +391,15 @@ class AdsSymbolTestCase(unittest.TestCase):
         structure_def = (
             ("a", pyads.PLCTYPE_INT, 1),
             ("b", pyads.PLCTYPE_INT, 1),
+            ("s", pyads.PLCTYPE_STRING, 1)
         )
-        values = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
+        values = [{"a": 1, "b": 2, "s": "foo"}, {"a": 3, "b": 4, "s": "bar"}]
         data = bytes(bytes_from_dict(values, structure_def))
 
         self.handler.add_variable(
             PLCVariable("TestStructure", data, constants.ADST_VOID, symbol_type="TestStructure"))
 
-        write_values = [{"a": 42, "b": 43}, {"a": 44, "b": 45}]
+        write_values = [{"a": 42, "b": 43, "s": "hello"}, {"a": 44, "b": 45, "s": "world"}]
         with self.plc:
             symbol = self.plc.get_symbol("TestStructure", structure_def=structure_def, array_size=2)
             symbol.write(write_values)

--- a/tests/test_symbol.py
+++ b/tests/test_symbol.py
@@ -325,9 +325,27 @@ class AdsSymbolTestCase(unittest.TestCase):
 
         with self.plc:
             symbol = self.plc.get_symbol("TestStructure", structure_def=structure_def)
-            read_data = symbol.read()
+            read_values = symbol.read()
 
-        self.assertEqual(values, read_data)
+        self.assertEqual(values, read_values)
+
+    def test_read_structure_array(self):
+        """Test symbol value reading with structures."""
+        structure_def = (
+            ("a", pyads.PLCTYPE_INT, 1),
+            ("b", pyads.PLCTYPE_INT, 1),
+        )
+        values = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
+        data = bytes(bytes_from_dict(values, structure_def))
+
+        self.handler.add_variable(
+            PLCVariable("TestStructure", data, constants.ADST_VOID, symbol_type="TestStructure"))
+
+        with self.plc:
+            symbol = self.plc.get_symbol("TestStructure", structure_def=structure_def, array_size=2)
+            read_values = symbol.read()
+
+        self.assertEqual(values, read_values)
 
     def test_write(self):
         """Test symbol value writing"""
@@ -362,6 +380,26 @@ class AdsSymbolTestCase(unittest.TestCase):
         write_values = {"i": 42, "s": "bar"}
         with self.plc:
             symbol = self.plc.get_symbol("TestStructure", structure_def=structure_def)
+            symbol.write(write_values)
+            read_values = symbol.read()
+
+        self.assertEqual(write_values, read_values)
+
+    def test_write_structure_array(self):
+        """Test symbol value reading with structures."""
+        structure_def = (
+            ("a", pyads.PLCTYPE_INT, 1),
+            ("b", pyads.PLCTYPE_INT, 1),
+        )
+        values = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
+        data = bytes(bytes_from_dict(values, structure_def))
+
+        self.handler.add_variable(
+            PLCVariable("TestStructure", data, constants.ADST_VOID, symbol_type="TestStructure"))
+
+        write_values = [{"a": 42, "b": 43}, {"a": 44, "b": 45}]
+        with self.plc:
+            symbol = self.plc.get_symbol("TestStructure", structure_def=structure_def, array_size=2)
             symbol.write(write_values)
             read_values = symbol.read()
 


### PR DESCRIPTION
This addresses #207 .

It adds structure_def and array_size parameters to Connection.get_symbol. This way symbols can be created for structures and arrays of structures.