### PR TITLE
Added pyads.testserver to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -157,7 +157,7 @@ setup(
     long_description_content_type='text/markdown',
     author="Stefan Lehmann",
     author_email="Stefan.St.Lehmann@gmail.com",
-    packages=["pyads"],
+    packages=["pyads", "pyads.testserver"],
     package_data={'pyads': ['adslib.so']},
     requires=[],
     install_requires=[],


### PR DESCRIPTION
Subdirectory of the testserver was not included in pyads 3.3.5.
Fixes #248 