### PR TITLE
fix decoding of symbol comments

### DIFF
--- a/pyads/structs.py
+++ b/pyads/structs.py
@@ -330,7 +330,7 @@ class SAdsSymbolEntry(Structure):
     def _get_string(self, offset: int, length: int) -> str:
         """Get portion of the bigger string buffer"""
         return bytes(self.stringBuffer[offset:(offset + length)]) \
-            .decode("utf-8")
+            .decode("windows-1252")
 
     @property
     def name(self) -> str:

--- a/pyads/structs.py
+++ b/pyads/structs.py
@@ -330,7 +330,7 @@ class SAdsSymbolEntry(Structure):
     def _get_string(self, offset: int, length: int) -> str:
         """Get portion of the bigger string buffer"""
         return bytes(self.stringBuffer[offset:(offset + length)]) \
-            .decode("windows-1252")
+            .decode("windows-1252")  # TwinCAT uses Windows encoding for non-ascii characters
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
It seems that the comment of a symbol is not encoded in utf-8 but in windows-1252.
I could not find it in the documentation of TwinCAT, but tested it on a Windows 10 machine with TwinCAT3.
It also matches the encoding used here: https://github.com/stlehmann/pyads/blob/fc7733d4d12b64bfb03384313ff54304e5c3ace8/pyads/utils.py#L56

The other strings that are decoded with the `_get_string` method must be ASCII, which is compatible, so changing this here should not be an issue.