### PR TITLE
Allow for platform dependent builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -178,4 +178,5 @@ setup(
     cmdclass=cmdclass,
     data_files=data_files,
     tests_require=['pytest', 'pytest-cov'],
+    has_ext_modules=lambda: True,
 )


### PR DESCRIPTION
Home Assistant has been having issues using this module in the last year(s).
The keep their own wheels repo and the automated system did not build platform dependent versions.
Since this module is building the adslib dependency in a special way, it goes unnoticed by setuptools.

The extra line added in this pull request mitigates the problem and creates a platform dependent filename for the wheel.

> https://stackoverflow.com/a/64921892 (by CiaranWelsh):
> Adding below line to setup arguments in setup.py
>
> `has_ext_modules=lambda: True
> `
>
> This let me build pyads-3.3.9-cp310-cp310-linux_x86_64.whl instead of pyads-3.3.9-py3-none-any.whl