### PR TITLE
Added TWINCATSDK environment variable to resolve Windows TcAdsll.dll

### DIFF
--- a/pyads/pyads_ex.py
+++ b/pyads/pyads_ex.py
@@ -57,14 +57,22 @@ _adsDLL: Union["ctypes.WinDLL", "ctypes.CDLL"]
 # load dynamic ADS library
 if platform_is_windows():  # pragma: no cover, skip Windows test
     dlldir_handle = None
-    if sys.version_info >= (3, 8) and "TWINCAT3DIR" in os.environ:
+    if sys.version_info >= (3, 8):
         # Starting with version 3.8, CPython does not consider the PATH environment
         # variable any more when resolving DLL paths. The following works with the default
         # installation of the Beckhoff TwinCAT ADS DLL.
-        dll_path = os.environ["TWINCAT3DIR"] + "\\..\\AdsApi\\TcAdsDll"
-        if platform.architecture()[0] == "64bit":
-            dll_path += "\\x64"
-        dlldir_handle = os.add_dll_directory(dll_path)
+        if "TWINCATSDK" in os.environ:
+            dll_path = os.environ["TWINCATSDK"] + "\\..\\.."
+            if platform.architecture()[0] == "64bit":
+                dll_path += "\\Common64"
+            else:
+                dll_path += "\\Common32"
+            dlldir_handle = os.add_dll_directory(dll_path)
+        elif "TWINCAT3DIR" in os.environ:
+            dll_path = os.environ["TWINCAT3DIR"] + "\\..\\AdsApi\\TcAdsDll"
+            if platform.architecture()[0] == "64bit":
+                dll_path += "\\x64"
+            dlldir_handle = os.add_dll_directory(dll_path)
     try:
         _adsDLL = ctypes.WinDLL("TcAdsDll.dll")  # type: ignore
     finally:

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ commands = discover
 deps = discover
 changedir = tests
 whitelist_externals=*
+passenv = TWINCATSDK TWINCAT3DIR
 
 [pytest]
 testpaths = tests


### PR DESCRIPTION
On Windows 11, for TwinCAT 4026.5, it seems TcAdsDll.dll has moved and we can not rely on TWINCAT3DIR. I have added to the resolution method to first search for a different variable TWINCATSDK, which seems to be the basis for the correct DLL. I've tested this on two separate systems.
