### PR TITLE
Fixes bug that causes AmsPorts in _adsDLL library to remain open

### DIFF
--- a/pyads/connection.py
+++ b/pyads/connection.py
@@ -75,6 +75,7 @@ from .pyads_ex import (
     adsSyncAddDeviceNotificationReqEx,
     adsSyncDelDeviceNotificationReqEx,
     adsSyncSetTimeoutEx,
+    ADSError,
 )
 from .structs import (
     AmsAddr,
@@ -195,7 +196,12 @@ class Connection(object):
         self._port = adsPortOpenEx()
 
         if linux:
-            adsAddRoute(self._adr.netIdStruct(), self.ip_address)
+            try:
+                adsAddRoute(self._adr.netIdStruct(), self.ip_address)
+            except ADSError:
+                adsPortCloseEx(self._port)
+                self._port = None
+                raise
 
         self._open = True
 


### PR DESCRIPTION
On Linux systems, if an exception was thrown from the adsAddRoute(...) function call in the Connection.open() function, after a port has been opened, there was no call to close that port. This lack of closing the port renders the underlying AmsPort to be unusable for later connections, and if all 128 AmsPorts end up in this state, all Connection objects are rendered useless.