### PR TITLE
fix dll path issue with Twincat 4026

### DIFF
--- a/pyads/pyads_ex.py
+++ b/pyads/pyads_ex.py
@@ -56,21 +56,26 @@ _adsDLL: Union["ctypes.WinDLL", "ctypes.CDLL"]
 
 # load dynamic ADS library
 if platform_is_windows():  # pragma: no cover, skip Windows test
-    dlldir_handle = None
+    dlldir_handle = []
     if sys.version_info >= (3, 8) and "TWINCAT3DIR" in os.environ:
         # Starting with version 3.8, CPython does not consider the PATH environment
         # variable any more when resolving DLL paths. The following works with the default
         # installation of the Beckhoff TwinCAT ADS DLL.
-        dll_path = os.environ["TWINCAT3DIR"] + "\\..\\AdsApi\\TcAdsDll"
+        dll_path = os.environ["TWINCAT3DIR"]
+         # 20240620 update with the versoin 4026
+        dll_path_v4023 = os.path.join(dll_path, "\\..\\AdsApi\\TcAdsDll")
+        dll_path_v4026 = os.path.join(dll_path, "..")
         if platform.architecture()[0] == "64bit":
-            dll_path += "\\x64"
-        dlldir_handle = os.add_dll_directory(dll_path)
+            dll_path_v4023 += "\\x64"
+            dll_path_v4026 += "\\Common64"
+        dlldir_handle.append(os.add_dll_directory(dll_path_v4023))
+        dlldir_handle.append(os.add_dll_directory(dll_path_v4026))
     try:
         _adsDLL = ctypes.WinDLL("TcAdsDll.dll")  # type: ignore
     finally:
-        if dlldir_handle:
+        for handle in dlldir_handle:
             # Do not clobber the load path for other modules
-            dlldir_handle.close()
+            handle.close()
     NOTEFUNC = ctypes.WINFUNCTYPE(  # type: ignore
         ctypes.c_void_p,
         ctypes.POINTER(SAmsAddr),


### PR DESCRIPTION
I was facing some issues with the Twincat 4026 with fresh installation. try to fix the dll path (TcAdsDll.dll)
![pyads](https://github.com/stlehmann/pyads/assets/72130405/39b504af-8dc1-4da5-9cf8-27dc9e87465a)
Fixed it with two dll_path both for 4024 ( earlier) and the new 4026 with pkg manager in windows platform. And tested in windows 10/11.