### PR TITLE
Fixed an issue with auto_update in connection with structs

### DIFF
--- a/pyads/symbol.py
+++ b/pyads/symbol.py
@@ -252,10 +252,10 @@ class AdsSymbol:
         """
 
         if attr is None:
-            if self.plc_type is not None:
-                attr = NotificationAttrib(length=sizeof(self.plc_type))
-            elif self.structure_def is not None:
+            if self.structure_def is not None:
                 attr = NotificationAttrib(length=self._structure_size)
+            else:
+                attr = NotificationAttrib(length=sizeof(self.plc_type))
 
         handles = self._plc.add_device_notification(
             (self.index_group, self.index_offset), attr, callback, user_handle

--- a/pyads/symbol.py
+++ b/pyads/symbol.py
@@ -252,7 +252,10 @@ class AdsSymbol:
         """
 
         if attr is None:
-            attr = NotificationAttrib(length=sizeof(self.plc_type))
+            if self.plc_type is not None:
+                attr = NotificationAttrib(length=sizeof(self.plc_type))
+            elif self.structure_def is not None:
+                attr = NotificationAttrib(length=self._structure_size)
 
         handles = self._plc.add_device_notification(
             (self.index_group, self.index_offset), attr, callback, user_handle


### PR DESCRIPTION
Fixed https://github.com/stlehmann/pyads/issues/372 by adjusting `add_device_notification()` to correctly set the length of `NotificationAttrib` to `_structure_size` if a structure is present. Thanks to @ascaron37 for reporting this.