### PR TITLE
fixing read_list_by_name looping on MAX_ADS_SUB_COMMANDS case with lo…

### DIFF
--- a/pyads/connection.py
+++ b/pyads/connection.py
@@ -598,8 +598,9 @@ class Connection(object):
                                 list(structure_defs.keys()))  # type: ignore
 
             for data_name, structure_def in structure_defs.items():  # type: ignore
-                result[data_name] = dict_from_bytes(result[data_name],
-                                                    structure_def)  # type: ignore
+                if data_name in result:
+                    result[data_name] = dict_from_bytes(result[data_name],
+                        structure_def)
 
             return result
 
@@ -691,7 +692,7 @@ class Connection(object):
         return adsSyncWriteByNameEx(
             self._port, self._adr, data_name, value, plc_datatype, handle=handle
         )
-    
+
     def write_list_by_name(
             self,
             data_names_and_values: Dict[str, Any],


### PR DESCRIPTION
This pull request fixes an issue encountered when using the read_list_by_name function with structure_defs. If more than 500 tags are read and structure_defs is provided with a size matching the tags being requested, the for loop in sum_read raises an error. This happens because the tag list is sliced, but structure_defs is not.

To address this, I adjusted the for loop to ensure that the sliced chunk also includes the corresponding tags in structure_defs. This change resolves the issue.