### PR TITLE
Updated quickstart to use TwinCAT3

### DIFF
--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -26,9 +26,9 @@ Quickstart
     >>>     route_name=ROUTE_NAME
     >>> )
 
-    >>> # connect to plc and open connection
+    >>> # connect to plc and open connection using TwinCAT3.
     >>> # route is added automatically to client on Linux, on Windows use the TwinCAT router
-    >>> plc = pyads.Connection('127.0.0.1.1.1', pyads.PORT_SPS1)
+    >>> plc = pyads.Connection('127.0.0.1.1.1', pyads.PORT_TC3PLC1)
     >>> plc.open()
 
     >>> # check the connection state


### PR DESCRIPTION
The quickstart was the only example using the TwinCAT 2 port without specifying it. Updated it to use the TwinCAT 3 port for consistency with the rest of the docs ([connections](https://github.com/stlehmann/pyads/blob/master/doc/documentation/routing.rst), [routing](https://github.com/stlehmann/pyads/blob/master/doc/documentation/routing.rst#id1)).