### PR TITLE
Changed to `cibuildwheel` for wheel building across platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - name: Checkout repository and submodules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Changed
+* Minimum Python version changed to 3.9 (Python 3.8 is no longer supported)
+* [#495](https://github.com/stlehmann/pyads/issues/495) Organizing of metadata in `pyproject.toml` 
+
 ## 3.5.1
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ readme = "README.md"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -20,11 +19,13 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",
 ]
-license = { text = "MIT" }
+license = "MIT"
+license-files = ["LICENSE"]
 dynamic = ["version"]
 dependencies = []
-requires-python = ">= 3.8,<4"
+requires-python = ">= 3.9,<4"
 # Outdated Python versions are still included, until they cause problems (after which they will bed dropped)
+# Python 3.8 cannot be used anymore because of a setuptoools minimum version
 
 [project.optional-dependencies]
 docs = [
@@ -50,8 +51,8 @@ Repository = "https://github.com/stlehmann/pyads"
 Documentation = "https://pyads.readthedocs.io"
 
 [build-system]
-requires = ["setuptools >= 70.1", "wheel"]
-# Minimum of 70.1 because of new location of `bdist_wheel`
+requires = ["setuptools >= 77.0.3", "wheel"]
+# ^ Support for new `license` format
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]


### PR DESCRIPTION
Resolves:
- #487 
- #483 

I think this pipeline is now according what's considered modern. 

**Important!** Now PyPi authentication is done based on a trusted publisher. This is the recommended authentication for deploy jobs like these. I set it up for my own testpypi and it's easy. See:
https://docs.pypi.org/trusted-publishers/using-a-publisher/ 

The test-version of these can be seen on my fork: https://github.com/RobertoRoos/pyads/pull/1
Release results can be seen on my Test-PyPi: https://test.pypi.org/project/pyads-Roberto/#history
You could even try a test install with: `pip install pyads_roberto -v --index-url https://test.pypi.org/simple/`

This will obviously need a squash-merge... :')