### PR TITLE
Added list read/write for symbols

### DIFF
--- a/doc/documentation/connection.rst
+++ b/doc/documentation/connection.rst
@@ -247,19 +247,35 @@ Read and write multiple variables with one command
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Reading and writing of multiple values can be performed in a single
-transaction. After the first operation, the symbol info is cached for
-future use.
+transaction. When using variable names, the symbol info is cached for
+future use after the first operation.
+
+.. code:: python
+
+   >>> import pyads
+   >>> plc = pyads.Connection('127.0.0.1.1.1', pyads.PORT_TC3PLC1)
+   >>> var_list = [symbol_1, symbol_2, symbol_3]
+   >>> plc.read_list(var_list)
+   {<pyads.ads.AdsSymbol, name 'MAIN.b_Execute'>: True, <pyads.ads.AdsSymbol, name 'MAIN.str_TestString'>: <pyads.ads.AdsSymbol>,
+            <pyads.ads.AdsSymbol, name 'r32_TestReal'>: 123.45}
+   >>> write_dict = {symbol_1: False, symbol_2: 'Goodbye World', symbol_3: 54.321}
+   >>> plc.write_list(write_dict)
+   {'MAIN.b_Execute': 'no error', 'MAIN.str_TestString': 'no error', 'MAIN.r32_TestReal': 'no error'}
+
+
+Or, when using variable names:
 
 .. code:: python
 
    >>> import pyads
    >>> plc = pyads.Connection('127.0.0.1.1.1', pyads.PORT_TC3PLC1)
    >>> var_list = ['MAIN.b_Execute', 'MAIN.str_TestString', 'MAIN.r32_TestReal']
-   >>> plc.read_list_by_name(var_list)
+   >>> plc.read_list(var_list)
    {'MAIN.b_Execute': True, 'MAIN.str_TestString': 'Hello World', 'MAIN.r32_TestReal': 123.45}
    >>> write_dict = {'MAIN.b_Execute': False, 'MAIN.str_TestString': 'Goodbye World', 'MAIN.r32_TestReal': 54.321}
-   >>> plc.write_list_by_name(write_dict)
+   >>> plc.write_list(write_dict)
    {'MAIN.b_Execute': 'no error', 'MAIN.str_TestString': 'no error', 'MAIN.r32_TestReal': 'no error'}
+
 
 Device Notifications
 ^^^^^^^^^^^^^^^^^^^^

--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -314,7 +314,7 @@ def dict_from_bytes(
                     if str_len is None:
                         str_len = PLC_DEFAULT_STRING_SIZE
                     var_array.append(
-                        bytearray(byte_list[index : (index + (str_len + 1))])
+                        bytearray(byte_list[index: (index + (str_len + 1))])
                         .partition(b"\0")[0]
                         .decode("utf-8")
                     )
@@ -326,7 +326,7 @@ def dict_from_bytes(
                     var_array.append(
                         struct.unpack(
                             DATATYPE_MAP[plc_datatype],
-                            bytearray(byte_list[index : (index + n_bytes)]),
+                            bytearray(byte_list[index: (index + n_bytes)]),
                         )[0]
                     )
                     index += n_bytes

--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -314,7 +314,7 @@ def dict_from_bytes(
                     if str_len is None:
                         str_len = PLC_DEFAULT_STRING_SIZE
                     var_array.append(
-                        bytearray(byte_list[index: (index + (str_len + 1))])
+                        bytearray(byte_list[index : (index + (str_len + 1))])
                         .partition(b"\0")[0]
                         .decode("utf-8")
                     )
@@ -326,7 +326,7 @@ def dict_from_bytes(
                     var_array.append(
                         struct.unpack(
                             DATATYPE_MAP[plc_datatype],
-                            bytearray(byte_list[index: (index + n_bytes)]),
+                            bytearray(byte_list[index : (index + n_bytes)]),
                         )[0]
                     )
                     index += n_bytes

--- a/pyads/connection.py
+++ b/pyads/connection.py
@@ -68,17 +68,13 @@ from .pyads_ex import (
     adsGetNetIdForPLC,
     adsGetSymbolInfo,
     adsSumRead,
-    adsSumReadBytes,
     adsSumWrite,
-    adsSumWriteBytes,
     adsReleaseHandle,
     adsSyncReadByNameEx,
     adsSyncWriteByNameEx,
     adsSyncAddDeviceNotificationReqEx,
     adsSyncDelDeviceNotificationReqEx,
     adsSyncSetTimeoutEx,
-    get_value_from_ctype_data,
-    type_is_string,
 )
 from .structs import (
     AmsAddr,
@@ -96,7 +92,6 @@ from .ads import (
     bytes_from_dict,
     size_of_structure,
 )
-from .errorcodes import ERROR_CODES
 from .symbol import AdsSymbol
 from .utils import decode_ads
 
@@ -114,7 +109,8 @@ class Connection(object):
     """
 
     def __init__(
-        self, ams_net_id: str = None, ams_net_port: int = None, ip_address: str = None
+            self, ams_net_id: str = None, ams_net_port: int = None,
+            ip_address: str = None
     ) -> None:
         self._port = None  # type: Optional[int]
         self._adr = AmsAddr(ams_net_id, ams_net_port)
@@ -171,9 +167,8 @@ class Connection(object):
         # If the connection is already closed, nothing new will happen
         self.close()
 
-    def _query_plc_datatype_from_name(
-        self, data_name: str, cache_symbol_info: bool
-    ) -> Type:
+    def _query_plc_datatype_from_name(self, data_name: str,
+                                      cache_symbol_info: bool) -> Type:
         """Return the plc_datatype by reading SymbolInfo from the target.
 
         If cache_symbol_info is True then the SymbolInfo will be cached and adsGetSymbolInfo
@@ -275,7 +270,7 @@ class Connection(object):
         return None
 
     def write_control(
-        self, ads_state: int, device_state: int, data: Any, plc_datatype: Type
+            self, ads_state: int, device_state: int, data: Any, plc_datatype: Type
     ) -> None:
         """Change the ADS state and the machine-state of the ADS-server.
 
@@ -311,11 +306,8 @@ class Connection(object):
         return None
 
     def write(
-        self,
-        index_group: int,
-        index_offset: int,
-        value: Any,
-        plc_datatype: Type["PLCDataType"],
+            self, index_group: int, index_offset: int, value: Any,
+            plc_datatype: Type["PLCDataType"]
     ) -> None:
         """Send data synchronous to an ADS-device.
 
@@ -333,14 +325,14 @@ class Connection(object):
             )
 
     def read_write(
-        self,
-        index_group: int,
-        index_offset: int,
-        plc_read_datatype: Optional[Type["PLCDataType"]],
-        value: Any,
-        plc_write_datatype: Optional[Type["PLCDataType"]],
-        return_ctypes: bool = False,
-        check_length: bool = True,
+            self,
+            index_group: int,
+            index_offset: int,
+            plc_read_datatype: Optional[Type["PLCDataType"]],
+            value: Any,
+            plc_write_datatype: Optional[Type["PLCDataType"]],
+            return_ctypes: bool = False,
+            check_length: bool = True,
     ) -> Any:
         """Read and write data synchronous from/to an ADS-device.
 
@@ -374,12 +366,12 @@ class Connection(object):
         return None
 
     def read(
-        self,
-        index_group: int,
-        index_offset: int,
-        plc_datatype: Type["PLCDataType"],
-        return_ctypes: bool = False,
-        check_length: bool = True,
+            self,
+            index_group: int,
+            index_offset: int,
+            plc_datatype: Type["PLCDataType"],
+            return_ctypes: bool = False,
+            check_length: bool = True,
     ) -> Any:
         """Read data synchronous from an ADS-device.
 
@@ -409,15 +401,15 @@ class Connection(object):
         return None
 
     def get_symbol(
-        self,
-        name: Optional[str] = None,
-        index_group: Optional[int] = None,
-        index_offset: Optional[int] = None,
-        plc_datatype: Optional[Union[Type["PLCDataType"], str]] = None,
-        comment: Optional[str] = None,
-        auto_update: bool = False,
-        structure_def: Optional["StructureDef"] = None,
-        array_size: Optional[int] = 1,
+            self,
+            name: Optional[str] = None,
+            index_group: Optional[int] = None,
+            index_offset: Optional[int] = None,
+            plc_datatype: Optional[Union[Type["PLCDataType"], str]] = None,
+            comment: Optional[str] = None,
+            auto_update: bool = False,
+            structure_def: Optional["StructureDef"] = None,
+            array_size: Optional[int] = 1,
     ) -> AdsSymbol:
         """Create a symbol instance
 
@@ -460,17 +452,9 @@ class Connection(object):
 
         """
 
-        return AdsSymbol(
-            self,
-            name,
-            index_group,
-            index_offset,
-            plc_datatype,
-            comment,
-            auto_update=auto_update,
-            structure_def=structure_def,
-            array_size=array_size,
-        )
+        return AdsSymbol(self, name, index_group, index_offset, plc_datatype,
+                         comment, auto_update=auto_update, structure_def=structure_def,
+                         array_size=array_size)
 
     def get_all_symbols(self) -> List[AdsSymbol]:
         """Read all symbols from an ADS-device.
@@ -488,9 +472,8 @@ class Connection(object):
             sym_count = struct.unpack("I", symbol_size_msg[0:4])[0]
             sym_list_length = struct.unpack("I", symbol_size_msg[4:8])[0]
 
-            data_type_creation_fn: Type = cast(
-                "Type", partial(create_string_buffer, sym_list_length)
-            )
+            data_type_creation_fn: Type = cast("Type", partial(create_string_buffer,
+                                                               sym_list_length))
             symbol_list_msg = self.read(
                 ADSIGRP_SYM_UPLOAD,
                 ADSIOFFS_DEVDATA_ADSSTATE,
@@ -502,10 +485,10 @@ class Connection(object):
 
             for idx in range(sym_count):
                 read_length, index_group, index_offset = struct.unpack(
-                    "III", symbol_list_msg[ptr + 0 : ptr + 12]
+                    "III", symbol_list_msg[ptr + 0: ptr + 12]
                 )
                 name_length, type_length, comment_length = struct.unpack(
-                    "HHH", symbol_list_msg[ptr + 24 : ptr + 30]
+                    "HHH", symbol_list_msg[ptr + 24: ptr + 30]
                 )
 
                 name_start_ptr = ptr + 30
@@ -520,14 +503,10 @@ class Connection(object):
                 comment = decode_ads(symbol_list_msg[comment_start_ptr:comment_end_ptr])
 
                 ptr = ptr + read_length
-                symbol = AdsSymbol(
-                    plc=self,
-                    name=name,
-                    index_group=index_group,
-                    index_offset=index_offset,
-                    symbol_type=symbol_type,
-                    comment=comment,
-                )
+                symbol = AdsSymbol(plc=self, name=name,
+                                   index_group=index_group,
+                                   index_offset=index_offset,
+                                   symbol_type=symbol_type, comment=comment)
                 symbols.append(symbol)
         return symbols
 
@@ -546,7 +525,7 @@ class Connection(object):
         return None
 
     def release_handle(self, handle: int) -> None:
-        """Release handle of a PLC-variable.
+        """ Release handle of a PLC-variable.
 
         :param int handle: handle of PLC-variable to be released
         """
@@ -554,13 +533,13 @@ class Connection(object):
             adsReleaseHandle(self._port, self._adr, handle)
 
     def read_by_name(
-        self,
-        data_name: str,
-        plc_datatype: Optional[Type["PLCDataType"]] = None,
-        return_ctypes: bool = False,
-        handle: Optional[int] = None,
-        check_length: bool = True,
-        cache_symbol_info: bool = True,
+            self,
+            data_name: str,
+            plc_datatype: Optional[Type["PLCDataType"]] = None,
+            return_ctypes: bool = False,
+            handle: Optional[int] = None,
+            check_length: bool = True,
+            cache_symbol_info: bool = True,
     ) -> Any:
         """Read data synchronous from an ADS-device from data name.
 
@@ -582,9 +561,8 @@ class Connection(object):
             return
 
         if plc_datatype is None:
-            plc_datatype = self._query_plc_datatype_from_name(
-                data_name, cache_symbol_info
-            )
+            plc_datatype = self._query_plc_datatype_from_name(data_name,
+                                                              cache_symbol_info)
 
         return adsSyncReadByNameEx(
             self._port,
@@ -751,11 +729,11 @@ class Connection(object):
         return return_data
 
     def write_list_by_name(
-        self,
-        data_names_and_values: Dict[str, Any],
-        cache_symbol_info: bool = True,
-        ads_sub_commands: int = MAX_ADS_SUB_COMMANDS,
-        structure_defs: Optional[Dict[str, StructureDef]] = None,
+            self,
+            data_names_and_values: Dict[str, Any],
+            cache_symbol_info: bool = True,
+            ads_sub_commands: int = MAX_ADS_SUB_COMMANDS,
+            structure_defs: Optional[Dict[str, StructureDef]] = None,
     ) -> Dict[str, str]:
         """Write a list of variables.
 
@@ -837,12 +815,12 @@ class Connection(object):
         )
 
     def read_structure_by_name(
-        self,
-        data_name: str,
-        structure_def: StructureDef,
-        array_size: Optional[int] = 1,
-        structure_size: Optional[int] = None,
-        handle: Optional[int] = None,
+            self,
+            data_name: str,
+            structure_def: StructureDef,
+            array_size: Optional[int] = 1,
+            structure_size: Optional[int] = None,
+            handle: Optional[int] = None,
     ) -> Optional[Union[Dict[str, Any], List[Dict[str, Any]]]]:
         """Read a structure of multiple types.
 
@@ -885,12 +863,12 @@ class Connection(object):
         return None
 
     def write_by_name(
-        self,
-        data_name: str,
-        value: Any,
-        plc_datatype: Optional[Type["PLCDataType"]] = None,
-        handle: Optional[int] = None,
-        cache_symbol_info: bool = True,
+            self,
+            data_name: str,
+            value: Any,
+            plc_datatype: Optional[Type["PLCDataType"]] = None,
+            handle: Optional[int] = None,
+            cache_symbol_info: bool = True,
     ) -> None:
         """Send data synchronous to an ADS-device from data name.
 
@@ -908,22 +886,21 @@ class Connection(object):
             return
 
         if plc_datatype is None:
-            plc_datatype = self._query_plc_datatype_from_name(
-                data_name, cache_symbol_info
-            )
+            plc_datatype = self._query_plc_datatype_from_name(data_name,
+                                                              cache_symbol_info)
 
         return adsSyncWriteByNameEx(
             self._port, self._adr, data_name, value, plc_datatype, handle=handle
         )
 
     def write_structure_by_name(
-        self,
-        data_name: str,
-        value: Union[Dict[str, Any], List[Dict[str, Any]]],
-        structure_def: StructureDef,
-        array_size: Optional[int] = 1,
-        structure_size: Optional[int] = None,
-        handle: Optional[int] = None,
+            self,
+            data_name: str,
+            value: Union[Dict[str, Any], List[Dict[str, Any]]],
+            structure_def: StructureDef,
+            array_size: Optional[int] = 1,
+            structure_size: Optional[int] = None,
+            handle: Optional[int] = None,
     ) -> None:
         """Write a structure of multiple types.
 
@@ -963,11 +940,11 @@ class Connection(object):
         )
 
     def add_device_notification(
-        self,
-        data: Union[str, Tuple[int, int]],
-        attr: NotificationAttrib,
-        callback: Callable,
-        user_handle: Optional[int] = None,
+            self,
+            data: Union[str, Tuple[int, int]],
+            attr: NotificationAttrib,
+            callback: Callable,
+            user_handle: Optional[int] = None,
     ) -> Optional[Tuple[int, int]]:
         """Add a device notification.
 
@@ -1022,7 +999,7 @@ class Connection(object):
         return None
 
     def del_device_notification(
-        self, notification_handle: int, user_handle: int
+            self, notification_handle: int, user_handle: int
     ) -> None:
         """Remove a device notification.
 
@@ -1051,7 +1028,8 @@ class Connection(object):
             adsSyncSetTimeoutEx(self._port, ms)
 
     def notification(
-        self, plc_datatype: Optional[Type] = None, timestamp_as_filetime: bool = False
+            self, plc_datatype: Optional[Type] = None,
+            timestamp_as_filetime: bool = False
     ) -> Callable:
         """Decorate a callback function.
 
@@ -1101,7 +1079,7 @@ class Connection(object):
         """
 
         def notification_decorator(
-            func: Callable[[int, str, Union[datetime, int], Any], None]
+                func: Callable[[int, str, Union[datetime, int], Any], None]
         ) -> Callable[[Any, str], None]:
             def func_wrapper(notification: Any, data_name: str) -> None:
                 h_notification, timestamp, value = self.parse_notification(
@@ -1115,53 +1093,53 @@ class Connection(object):
 
     # noinspection PyMethodMayBeStatic
     def parse_notification(
-        self,
-        notification: Any,
-        plc_datatype: Optional[Type],
-        timestamp_as_filetime: bool = False,
+            self,
+            notification: Any,
+            plc_datatype: Optional[Type],
+            timestamp_as_filetime: bool = False,
     ) -> Tuple[int, Union[datetime, int], Any]:
         # noinspection PyTypeChecker
         """Parse a notification.
 
-        Convert the data of the NotificationHeader into the fitting Python type.
+                        Convert the data of the NotificationHeader into the fitting Python type.
 
-        :param notification: The notification we recieve from PLC datatype to be
-            converted. This can be any basic PLC datatype or a `ctypes.Structure`.
-        :param plc_datatype: The PLC datatype that needs to be converted. This can
-            be any basic PLC datatype or a `ctypes.Structure`.
-        :param timestamp_as_filetime: Whether the notification timestamp should be returned
-            as `datetime.datetime` (False) or Windows `FILETIME` as originally transmitted
-            via ADS (True). Be aware that the precision of `datetime.datetime` is limited to
-            microseconds, while FILETIME allows for 100 ns. This may be relevant when using
-            task cycle times such as 62.5 µs. Default: False.
+                        :param notification: The notification we recieve from PLC datatype to be
+                            converted. This can be any basic PLC datatype or a `ctypes.Structure`.
+                        :param plc_datatype: The PLC datatype that needs to be converted. This can
+                            be any basic PLC datatype or a `ctypes.Structure`.
+                        :param timestamp_as_filetime: Whether the notification timestamp should be returned
+                            as `datetime.datetime` (False) or Windows `FILETIME` as originally transmitted
+                            via ADS (True). Be aware that the precision of `datetime.datetime` is limited to
+                            microseconds, while FILETIME allows for 100 ns. This may be relevant when using
+                            task cycle times such as 62.5 µs. Default: False.
 
-        :rtype: (int, int, Any)
-        :returns: notification handle, timestamp, value
+                        :rtype: (int, int, Any)
+                        :returns: notification handle, timestamp, value
 
-        **Usage**:
+                        **Usage**:
 
-        >>> import pyads
-        >>> from ctypes import sizeof
-        >>>
-        >>> # Connect to the local TwinCAT PLC
-        >>> plc = pyads.Connection('127.0.0.1.1.1', 851)
-        >>> tag = {"GVL.myvalue": pyads.PLCTYPE_INT}
-        >>>
-        >>> # Create callback function that prints the value
-        >>> def mycallback(notification: SAdsNotificationHeader, data: str) -> None:
-        >>>     data_type = tag[data]
-        >>>     handle, timestamp, value = plc.parse_notification(notification, data_type)
-        >>>     print(value)
-        >>>
-        >>> with plc:
-        >>>     # Add notification with default settings
-        >>>     attr = pyads.NotificationAttrib(sizeof(pyads.PLCTYPE_INT))
-        >>>
-        >>>     handles = plc.add_device_notification("GVL.myvalue", attr, mycallback)
-        >>>
-        >>>     # Remove notification
-        >>>     plc.del_device_notification(handles)
-        """
+                        >>> import pyads
+                        >>> from ctypes import sizeof
+                        >>>
+                        >>> # Connect to the local TwinCAT PLC
+                        >>> plc = pyads.Connection('127.0.0.1.1.1', 851)
+                        >>> tag = {"GVL.myvalue": pyads.PLCTYPE_INT}
+                        >>>
+                        >>> # Create callback function that prints the value
+                        >>> def mycallback(notification: SAdsNotificationHeader, data: str) -> None:
+                        >>>     data_type = tag[data]
+                        >>>     handle, timestamp, value = plc.parse_notification(notification, data_type)
+                        >>>     print(value)
+                        >>>
+                        >>> with plc:
+                        >>>     # Add notification with default settings
+                        >>>     attr = pyads.NotificationAttrib(sizeof(pyads.PLCTYPE_INT))
+                        >>>
+                        >>>     handles = plc.add_device_notification("GVL.myvalue", attr, mycallback)
+                        >>>
+                        >>>     # Remove notification
+                        >>>     plc.del_device_notification(handles)
+                        """
         contents = notification.contents
         data_size = contents.cbSampleSize
         # Get dynamically sized data array

--- a/pyads/connection.py
+++ b/pyads/connection.py
@@ -904,7 +904,7 @@ class Connection(object):
             offset += 12
 
         if isinstance(symbols, dict):
-            new_values = list(symbols.keys())
+            new_values = list(symbols.values())
         else:
             new_values = None
 

--- a/pyads/connection.py
+++ b/pyads/connection.py
@@ -574,15 +574,118 @@ class Connection(object):
             check_length=check_length,
         )
 
-    def _read_list(
+    def read_list(
+        self,
+        symbols: Union[List[str], List[AdsSymbol]],
+        cache_symbol_info: bool = True,
+        ads_sub_commands: int = MAX_ADS_SUB_COMMANDS,
+        structure_defs: Optional[Dict[str, StructureDef]] = None,
+    ) -> Dict[str, Any]:
+        """Read a list of variables in a combined request.
+
+        Either a list of symbol objects or a list of symbol names can be passed.
+
+        A dictionary with the new values will be returned. When using a list of
+        symbols, the internal cache of those symbols will be updated too.
+
+        Will split the read into multiple ADS calls in chunks of ads_sub_commands by default.
+        MAX_ADS_SUB_COMMANDS comes from Beckhoff recommendation:
+        https://infosys.beckhoff.com/english.php?content=../content/1033/tc3_adsdll2/9007199379576075.html&id=9180083787138954512
+
+        :param symbols: list of variable names to be read
+        :param cache_symbol_info: when True, symbol info will be cached for future
+            reading (only relevant when using variable names instead of symbol instances)
+        :param ads_sub_commands: Max number of ADS-Sub commands used to read the variables in a single ADS call.
+            A larger number can be used but may jitter the PLC execution!
+        :param structure_defs: for structured variables, optional mapping of
+            data name to special tuple defining the structure and types contained within it according to PLCTYPE constants
+        :return A dictionary containing variable names from data_names as keys and values read from PLC for each variable
+        """
+
+        # Check type the first element only
+        if symbols and isinstance(symbols[0], str):
+            return self.read_list_by_name(symbols, cache_symbol_info,
+                                          ads_sub_commands, structure_defs)
+
+        return self._read_list_of_symbols(symbols, ads_sub_commands)
+
+    def read_list_by_name(
+        self,
+        data_names: List[str],
+        cache_symbol_info: bool = True,
+        ads_sub_commands: int = MAX_ADS_SUB_COMMANDS,
+        structure_defs: Optional[Dict[str, StructureDef]] = None,
+    ) -> Dict[str, Any]:
+        """Read a list of variables by string name.
+
+        This method will be deprecated, it is recommended to use :meth:`read_list()`
+        instead.
+
+        :param data_names: list of variable names to be read
+        :param cache_symbol_info: when True, symbol info will be cached for future reading
+        :param ads_sub_commands: Max number of ADS-Sub commands used to read the variables in a single ADS call.
+            A larger number can be used but may jitter the PLC execution!
+        :param structure_defs: for structured variables, optional mapping of
+            data name to special tuple defining the structure and types contained within it according to PLCTYPE constants
+        :return A dictionary containing variable names from data_names as keys and values read from PLC for each variable
+        """
+        if structure_defs is None:
+            structure_defs = {}
+
+        data_symbols = self._get_info_dict_for_names_list(data_names, cache_symbol_info)
+
+        return self._read_list_by_info(data_symbols, ads_sub_commands, structure_defs)
+
+    def _read_list_of_symbols(
+        self,
+        symbols: List[AdsSymbol],
+        ads_sub_commands: int = MAX_ADS_SUB_COMMANDS,
+    ):
+        """Read new values for a list of AdsSymbols using a single ADS call.
+
+        The outputs will be returned as a dictionary, but the cache of each symbol will
+        be updated too.
+
+        It is recommended to use :meth:`read_list` instead for outside applications.
+        See also :class:`pyads.AdsSymbol`.
+
+        :param symbols: List if symbol instances
+        :param ads_sub_commands: Max. number of symbols per call (see
+                                 `read_list_by_name`)
+        """
+
+        for symbol in symbols:
+            if symbol.is_structure:
+                raise ValueError("Method not available for structured variables")
+
+        # Relying on `adsSumRead()` is tricky, because we do not have the `dataType`
+        # (integer) for each symbol, we only have the ctypes-type.
+
+        data_symbols = {
+            symbol.name: (symbol.index_group, symbol.index_offset, symbol.plc_type)
+            for symbol in symbols
+        }
+
+        result = self._read_list_by_info(data_symbols, ads_sub_commands, {})
+
+        # Add result to symbols cache
+        for symbol in symbols:
+            symbol._value = result[symbol.name]
+
+        return result
+
+    def _read_list_by_info(
         self,
         data_symbols: Dict[str, Union[SAdsSymbolEntry, Tuple]],
         ads_sub_commands: int,
         structure_defs: Dict[str, StructureDef],
     ) -> Dict[str, Any]:
-        """Perform read for a list of variables.
+        """Perform read for a list of variables where all info is already known.
 
-        See :meth:`Connection.read_list_by_name`.
+        `data_symbols` can be a dict with SymbolEntry structs or with tuples like
+        `(idx_group, idx_offset, plc_type)`.
+
+        See :meth:`read_list` for usage.
         """
 
         data_names = list(data_symbols.keys())
@@ -614,85 +717,139 @@ class Connection(object):
 
         return return_data
 
-    def read_list_by_name(
-        self,
-        data_names: List[str],
-        cache_symbol_info: bool = True,
-        ads_sub_commands: int = MAX_ADS_SUB_COMMANDS,
-        structure_defs: Optional[Dict[str, StructureDef]] = None,
-    ) -> Dict[str, Any]:
-        """Read a list of variables.
+    def write_list(
+            self,
+            data_names_and_values: Dict[Union[str, AdsSymbol], Any],
+            cache_symbol_info: bool = True,
+            ads_sub_commands: int = MAX_ADS_SUB_COMMANDS,
+            structure_defs: Optional[Dict[str, StructureDef]] = None,
+    ) -> Dict[str, str]:
+        """Write a list of variables in a combined request.
 
-        Will split the read into multiple ADS calls in chunks of ads_sub_commands by default.
+        The dictionary can either be indexed by `AdsSymbol` instances or by the
+        variable names.
+
+        A dictionary with error messages will be returned.
+        When `AdsSymbol` instances are used, the new values will also be written in
+        the internal object cache.
+
+        See `meth`:read_list` for the meaning of `ads_sub_commands`.
+
+        :param data_names_and_values: dictionary of variable names and their values to be written
+        :param cache_symbol_info: when True, symbol info will be cached for future
+            reading (only relevant when using variable names instead of symbol instances)
+        :param ads_sub_commands: Max number of ADS-Sub commands used to write the variables in a single ADS call.
+            A larger number can be used but may jitter the PLC execution!
+        :param structure_defs: for structured variables, optional mapping of
+            data name to special tuple defining the structure and
+            types contained within it according to PLCTYPE constants
+        :return A dictionary containing variable names from data_names as keys and values return codes for
+            each write operation from the PLC
+        """
+
+        # Check type the first element only
+        if data_names_and_values and isinstance(list(data_names_and_values)[0], str):
+            return self.write_list_by_name(data_names_and_values, cache_symbol_info,
+                                          ads_sub_commands, structure_defs)
+
+        return self._write_list_of_symbols(data_names_and_values, ads_sub_commands)
+
+    def write_list_by_name(
+            self,
+            data_names_and_values: Dict[str, Any],
+            cache_symbol_info: bool = True,
+            ads_sub_commands: int = MAX_ADS_SUB_COMMANDS,
+            structure_defs: Optional[Dict[str, StructureDef]] = None,
+    ) -> Dict[str, str]:
+        """Write a list of variables.
+
+        Will split the write into multiple ADS calls in chunks of ads_sub_commands by default.
 
         MAX_ADS_SUB_COMMANDS comes from Beckhoff recommendation:
         https://infosys.beckhoff.com/english.php?content=../content/1033/tc3_adsdll2/9007199379576075.html&id=9180083787138954512
 
-        :param List[str] data_names: list of variable names to be read
-        :param bool cache_symbol_info: when True, symbol info will be cached for future reading
-        :param int ads_sub_commands: Max number of ADS-Sub commands used to read the variables in a single ADS call.
+        :param data_names_and_values: dictionary of variable names and their values to be written
+        :param cache_symbol_info: when True, symbol info will be cached for future reading
+        :param ads_sub_commands: Max number of ADS-Sub commands used to write the variables in a single ADS call.
             A larger number can be used but may jitter the PLC execution!
-        :param Optional[Dict[str, StructureDef]] structure_defs: for structured variables, optional mapping of
-            data name to special tuple defining the structure and types contained within it according to PLCTYPE constants
-        :return adsSumRead: A dictionary containing variable names from data_names as keys and values read from PLC for each variable
-        :rtype: Dict[str, Any]
-
+        :param structure_defs: for structured variables, optional mapping of
+            data name to special tuple defining the structure and
+            types contained within it according to PLCTYPE constants
+        :return A dictionary containing variable names from data_names as keys and values return codes for
+            each write operation from the PLC
         """
         if structure_defs is None:
             structure_defs = {}
 
-        data_symbols = self._get_info_dict_for_names_list(data_names, cache_symbol_info)
+        data_symbols = self._get_info_dict_for_names_list(
+            list(data_names_and_values.keys()), cache_symbol_info
+        )
 
-        return self._read_list(data_symbols, ads_sub_commands, structure_defs)
+        return self._write_list_by_info(
+            data_symbols, data_names_and_values, ads_sub_commands, structure_defs
+        )
 
-    def read_list_of_symbols(
+    def _write_list_of_symbols(
         self,
-        symbols: List[AdsSymbol],
+        symbols_and_values: Dict[AdsSymbol, Any],
         ads_sub_commands: int = MAX_ADS_SUB_COMMANDS,
     ):
-        """Read new values for a list of AdsSymbols using a single ADS call.
+        """Write new values to a list of symbols.
 
-        The outputs will be returned as a dictionary, but the cache of each symbol will
-        be updated too.
+        Either specify a dict of symbols, or first set the `_value` property of
+        each symbol and then pass them as a list.
 
-        Comparable to :meth:`Connection.read_list_by_name`.
+        For example:
+
+        .. code:: python
+
+            # Using dict
+            new_data = {symbol1: 3.14, symbol2: False}
+            plc._write_list_of_symbols(new_data)
+
+            # Using cache
+            symbol1._value = 3.14
+            symbol2._value = False
+            plc._write_list_of_symbols([symbol1, symbol2])
+
+        It is recommended to use :meth:`write_list` instead for outside applications.
         See also :class:`pyads.AdsSymbol`.
 
-        :param symbols: List if symbol instances
+        :param symbols_and_values: Symbols to write to
         :param ads_sub_commands: Max. number of symbols per call (see
-                                 `read_list_by_name`)
+                                 `write_list_by_name`)
         """
 
-        for symbol in symbols:
+        for symbol in symbols_and_values.keys():
             if symbol.is_structure:
                 raise ValueError("Method not available for structured variables")
 
-        # Relying on `adsSumRead()` is tricky, because we do not have the `dataType`
-        # (integer) for each symbol, we only have the ctypes-type.
-
         data_symbols = {
             symbol.name: (symbol.index_group, symbol.index_offset, symbol.plc_type)
-            for symbol in symbols
+            for symbol in symbols_and_values.keys()
         }
 
-        result = self._read_list(data_symbols, ads_sub_commands, {})
+        data_names_and_values = {
+            symbol.name: new_value for symbol, new_value in symbols_and_values.items()
+        }
 
-        # Add result to symbols cache
-        for symbol in symbols:
-            symbol._value = result[symbol.name]
+        for symbol, new_value in symbols_and_values.items():
+            symbol._value = new_value  # Update cache
 
-        return result
+        return self._write_list_by_info(
+            data_symbols, data_names_and_values, ads_sub_commands, {}
+        )
 
-    def _write_list(
+    def _write_list_by_info(
         self,
         data_symbols: Dict[str, Union[SAdsSymbolEntry, Tuple]],
         data_names_and_values: Dict[str, Any],
         ads_sub_commands: int,
         structure_defs: Dict[str, StructureDef],
     ) -> Dict[str, str]:
-        """Write a list of variables.
+        """Write a list of variables where the info is already known.
 
-        See :meth:`write_list_by_name`.
+        See :meth:`write_list` for usage.
         """
 
         # Copy so the original does not get modified
@@ -727,92 +884,6 @@ class Connection(object):
             return_data.update(result)
 
         return return_data
-
-    def write_list_by_name(
-            self,
-            data_names_and_values: Dict[str, Any],
-            cache_symbol_info: bool = True,
-            ads_sub_commands: int = MAX_ADS_SUB_COMMANDS,
-            structure_defs: Optional[Dict[str, StructureDef]] = None,
-    ) -> Dict[str, str]:
-        """Write a list of variables.
-
-        Will split the write into multiple ADS calls in chunks of ads_sub_commands by default.
-
-        MAX_ADS_SUB_COMMANDS comes from Beckhoff recommendation:
-        https://infosys.beckhoff.com/english.php?content=../content/1033/tc3_adsdll2/9007199379576075.html&id=9180083787138954512
-
-        :param data_names_and_values: dictionary of variable names and their values to be written
-        :type data_names_and_values: dict[str, Any]
-        :param bool cache_symbol_info: when True, symbol info will be cached for future reading
-        :param int ads_sub_commands: Max number of ADS-Sub commands used to write the variables in a single ADS call.
-            A larger number can be used but may jitter the PLC execution!
-        :param dict structure_defs: for structured variables, optional mapping of
-            data name to special tuple defining the structure and
-            types contained within it according to PLCTYPE constants
-        :return adsSumWrite: A dictionary containing variable names from data_names as keys and values return codes for
-            each write operation from the PLC
-        :rtype: dict(str, str)
-
-        """
-        if structure_defs is None:
-            structure_defs = {}
-
-        data_symbols = self._get_info_dict_for_names_list(
-            list(data_names_and_values.keys()), cache_symbol_info
-        )
-
-        return self._write_list(
-            data_symbols, data_names_and_values, ads_sub_commands, structure_defs
-        )
-
-    def write_list_of_symbols(
-        self,
-        symbols_and_values: Dict[AdsSymbol, Any],
-        ads_sub_commands: int = MAX_ADS_SUB_COMMANDS,
-    ):
-        """Write new values to a list of symbols.
-
-        Either specify a dict of symbols, or first set the `_value` property of
-        each symbol and then pass them as a list.
-
-        For example:
-
-        .. code:: python
-
-            # Using dict
-            new_data = {symbol1: 3.14, symbol2: False}
-            plc.write_list_of_symbols(new_data)
-
-            # Using cache
-            symbol1._value = 3.14
-            symbol2._value = False
-            plc.write_list_of_symbols([symbol1, symbol2])
-
-        Comparable to :meth:`Connection.write_list_by_name`.
-        See also :class:`pyads.AdsSymbol`.
-
-        :param symbols_and_values: Symbols to write to
-        :param ads_sub_commands: Max. number of symbols per call (see
-                                 `write_list_by_name`)
-        """
-
-        for symbol in symbols_and_values.keys():
-            if symbol.is_structure:
-                raise ValueError("Method not available for structured variables")
-
-        data_symbols = {
-            symbol.name: (symbol.index_group, symbol.index_offset, symbol.plc_type)
-            for symbol in symbols_and_values.keys()
-        }
-
-        data_names_and_values = {
-            symbol.name: value for symbol, value in symbols_and_values.items()
-        }
-
-        return self._write_list(
-            data_symbols, data_names_and_values, ads_sub_commands, {}
-        )
 
     def read_structure_by_name(
             self,

--- a/pyads/pyads_ex.py
+++ b/pyads/pyads_ex.py
@@ -115,7 +115,9 @@ elif platform_is_freebsd():
 else:  # pragma: no cover, can not test unsupported platform
     raise RuntimeError("Unsupported platform {0}.".format(sys.platform))
 
-callback_store: Dict[Tuple[AmsAddr, int], Callable[[SAmsAddr, SAdsNotificationHeader, int], None]] = dict()
+callback_store: Dict[
+    Tuple[AmsAddr, int], Callable[[SAmsAddr, SAdsNotificationHeader, int], None]
+] = dict()
 
 
 class ADSError(Exception):
@@ -356,11 +358,11 @@ def adsAddRouteToPLC(
 
 def adsGetNetIdForPLC(ip_address: str) -> str:
     """Get AMS Net ID from IP address.
-    
+
     :param str ip_address: ip address of the PLC
     :rtype: str
     :return: net id of the device at the provided ip address
-    
+
     """
     # The head of the UDP AMS packet containing host routing information
     data_header = struct.pack(
@@ -953,13 +955,21 @@ def adsSumRead(
 
     if type_symbol_entry:
         symbol_infos = [
-            (data_symbols[name].iGroup, data_symbols[name].iOffs,
-             data_symbols[name].size) for name in data_names
+            (
+                data_symbols[name].iGroup,
+                data_symbols[name].iOffs,
+                data_symbols[name].size,
+            )
+            for name in data_names
         ]
     else:
         symbol_infos = [
-            (data_symbols[name][0], data_symbols[name][1],
-             sizeof(data_symbols[name][2])) for name in data_names
+            (
+                data_symbols[name][0],
+                data_symbols[name][1],
+                sizeof(data_symbols[name][2]),
+            )
+            for name in data_names
         ]
     # When a read is split, `data_symbols` will be bigger than `data_names`
     # Therefore we avoid looping over `data_symbols`
@@ -978,13 +988,16 @@ def adsSumRead(
         if error:
             result[data_name] = ERROR_CODES[error]
         else:
-            sum_response_subset = sum_response[offset: offset + size]
+            sum_response_subset = sum_response[offset : offset + size]
 
             if data_name in structured_data_names:
                 value = sum_response_subset
             else:
-                if type_symbol_entry:   # Data type (int)
-                    if symbol.dataType != ADST_STRING and symbol.dataType != ADST_WSTRING:
+                if type_symbol_entry:  # Data type (int)
+                    if (
+                        symbol.dataType != ADST_STRING
+                        and symbol.dataType != ADST_WSTRING
+                    ):
                         value = struct.unpack_from(
                             DATATYPE_MAP[ads_type_to_ctype[symbol.dataType]],
                             sum_response,
@@ -993,9 +1006,9 @@ def adsSumRead(
                     else:
                         null_idx = sum_response_subset.index(0)
                         value = bytearray(
-                            sum_response[offset: offset + null_idx]
+                            sum_response[offset : offset + null_idx]
                         ).decode("utf-8")
-                else:                   # PLC Type (ctypes)
+                else:  # PLC Type (ctypes)
                     # Create ctypes instance, then convert to Python value
                     obj = symbol[2].from_buffer(sum_response, offset)
                     value = get_value_from_ctype_data(obj, symbol[2])
@@ -1060,7 +1073,9 @@ def adsSumWrite(
     :rtype: dict[str, ADSError]
     """
 
-    type_symbol_entry = not isinstance(data_symbols[list(data_names_and_values)[0]], tuple)
+    type_symbol_entry = not isinstance(
+        data_symbols[list(data_names_and_values)[0]], tuple
+    )
 
     offset = 0
     num_requests = len(data_names_and_values)
@@ -1095,7 +1110,7 @@ def adsSumWrite(
         size = symbol.size if type_symbol_entry else sizeof(symbol[2])
 
         if data_name in structured_data_names:
-            buf[offset: offset + size] = value
+            buf[offset : offset + size] = value
         else:
             if type_symbol_entry:
                 if symbol.dataType != ADST_STRING and symbol.dataType != ADST_WSTRING:
@@ -1106,10 +1121,10 @@ def adsSumWrite(
                         value,
                     )
                 else:
-                    buf[offset: offset + len(value)] = value.encode("utf-8")
+                    buf[offset : offset + len(value)] = value.encode("utf-8")
             else:
                 if type_is_string(symbol[2]):
-                    buf[offset: offset + len(value)] = value.encode("utf-8")
+                    buf[offset : offset + len(value)] = value.encode("utf-8")
                 else:
                     # Create ctypes instance from Python value
                     if type(symbol[2]).__name__ == "PyCArrayType":
@@ -1118,7 +1133,7 @@ def adsSumWrite(
                         write_data = value
                     else:
                         write_data = symbol[2](value)
-                    buf[offset: offset + size] = bytes(write_data)
+                    buf[offset : offset + size] = bytes(write_data)
 
         offset += size
 
@@ -1288,8 +1303,9 @@ def adsSyncAddDeviceNotificationReqEx(
     adsSyncAddDeviceNotificationReqFct.restype = ctypes.c_long
 
     # noinspection PyUnusedLocal
-    def wrapper(addr: SAmsAddr, notification: SAdsNotificationHeader, user: int) -> Callable[
-            [SAdsNotificationHeader, str], None]:
+    def wrapper(
+        addr: SAmsAddr, notification: SAdsNotificationHeader, user: int
+    ) -> Callable[[SAdsNotificationHeader, str], None]:
         return callback(notification, data)
 
     # noinspection PyTypeChecker

--- a/pyads/pyads_ex.py
+++ b/pyads/pyads_ex.py
@@ -93,7 +93,7 @@ elif platform_is_linux():
         ctypes.POINTER(SAdsNotificationHeader),
         ctypes.c_ulong,
     )
-    
+
 elif platform_is_freebsd():
     # try to load local libTcAdsDll.so in favor to global one
     local_adslib = os.path.join(os.path.dirname(__file__), "libTcAdsDll.so")
@@ -110,7 +110,7 @@ elif platform_is_freebsd():
         ctypes.POINTER(SAdsNotificationHeader),
         ctypes.c_ulong,
     )
-    
+
 else:  # pragma: no cover, can not test unsupported platform
     raise RuntimeError("Unsupported platform {0}.".format(sys.platform))
 

--- a/pyads/pyads_ex.py
+++ b/pyads/pyads_ex.py
@@ -115,9 +115,7 @@ elif platform_is_freebsd():
 else:  # pragma: no cover, can not test unsupported platform
     raise RuntimeError("Unsupported platform {0}.".format(sys.platform))
 
-callback_store: Dict[
-    Tuple[AmsAddr, int], Callable[[SAmsAddr, SAdsNotificationHeader, int], None]
-] = dict()
+callback_store: Dict[Tuple[AmsAddr, int], Callable[[SAmsAddr, SAdsNotificationHeader, int], None]] = dict()
 
 
 class ADSError(Exception):
@@ -1303,9 +1301,8 @@ def adsSyncAddDeviceNotificationReqEx(
     adsSyncAddDeviceNotificationReqFct.restype = ctypes.c_long
 
     # noinspection PyUnusedLocal
-    def wrapper(
-        addr: SAmsAddr, notification: SAdsNotificationHeader, user: int
-    ) -> Callable[[SAdsNotificationHeader, str], None]:
+    def wrapper(addr: SAmsAddr, notification: SAdsNotificationHeader, user: int) -> Callable[
+            [SAdsNotificationHeader, str], None]:
         return callback(notification, data)
 
     # noinspection PyTypeChecker

--- a/pyads/symbol.py
+++ b/pyads/symbol.py
@@ -22,8 +22,9 @@ from .structs import NotificationAttrib
 
 # ads.Connection relies on structs.AdsSymbol (but in type hints only), so use
 # this 'if' to only include it when type hinting (False during execution)
-if TYPE_CHECKING:
-    from .ads import Connection, StructureDef  # pragma: no cover
+if TYPE_CHECKING:  # pragma: no cover
+    from .connection import Connection
+    from .ads import StructureDef
 
 
 class AdsSymbol:

--- a/tests/test_connection_class.py
+++ b/tests/test_connection_class.py
@@ -7,7 +7,7 @@
 
 """
 import ctypes
-from ctypes import addressof, memmove, resize, sizeof, pointer
+from ctypes import memmove, resize, sizeof, pointer
 import datetime
 import time
 import unittest
@@ -15,7 +15,7 @@ import pyads
 import struct
 from pyads.testserver import AdsTestServer, AmsPacket, AdvancedHandler, PLCVariable
 from pyads.structs import NotificationAttrib
-from pyads import constants, structs
+from pyads import constants, structs, AdsSymbol
 from collections import OrderedDict
 
 # These are pretty arbitrary
@@ -1441,6 +1441,97 @@ class AdsApiTestCaseAdvanced(unittest.TestCase):
         """Test write_control for AdvancedHandler."""
         with self.plc:
             self.plc.write_control(constants.ADSSTATE_IDLE, 0, 0, constants.PLCTYPE_INT)
+
+
+class ConnectionSymbolListTestCase(unittest.TestCase):
+    """Testcase for the symbol list methods of the Connection class.
+
+    This is a separate test case to use the advanced handler with a few prepared
+    dummy variables.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        # type: () -> None
+        """Setup the ADS test server."""
+        cls.handler = AdvancedHandler()
+        cls.test_server = AdsTestServer(handler=cls.handler, logging=False)
+        cls.test_server.start()
+
+        # wait a bit otherwise error might occur
+        time.sleep(1)
+
+    @classmethod
+    def tearDownClass(cls):
+        # type: () -> None
+        """Tear down the test server."""
+        cls.test_server.stop()
+
+        # wait a bit for server to shutdown
+        time.sleep(1)
+
+    def setUp(self):
+        # type: () -> None
+        """Establish connection to the test server."""
+
+        # Clear test server and handler
+        self.test_server.request_history = []
+        self.handler.reset()
+
+        # Create PLC variables that are added by default
+        self.vars = [
+            PLCVariable(
+                "Double1", struct.pack("d", 3.14), ads_type=constants.ADST_REAL64,
+                symbol_type="LREAL"
+            ),
+            PLCVariable(
+                "Double2", struct.pack("d", 1.54), ads_type=constants.ADST_REAL64,
+                symbol_type="LREAL"
+            ),
+            PLCVariable(
+                "Int1", struct.pack("H", 420), ads_type=constants.ADST_UINT16,
+                symbol_type="UINT"
+            ),
+        ]
+
+        for var in self.vars:
+            self.handler.add_variable(var)
+
+        self.plc = pyads.Connection(
+            TEST_SERVER_AMS_NET_ID, TEST_SERVER_AMS_PORT, TEST_SERVER_IP_ADDRESS
+        )
+
+    def test_read_list_of_symbols(self):
+        """Test reading a list of symbols at once."""
+
+        with self.plc:
+            symbols = [AdsSymbol(self.plc, name=var.name) for var in self.vars]
+
+            result = self.plc.read_list_of_symbols(symbols)
+
+        expected = {"Double1": 3.14, "Double2": 1.54, "Int1": 420}
+        self.assertEqual(expected, result)
+
+        # Also check variable buffer
+        for symbol in symbols:
+            self.assertEqual(expected[symbol.name], symbol._value)
+
+    def test_write_list_of_symbols(self):
+        """Test writing a list of symbols at once, using a dictionary"""
+
+        with self.plc:
+            symbols = [AdsSymbol(self.plc, name=var.name) for var in self.vars]
+
+            values = [16.16, 25.55, 53]
+            symbols_with_data = dict(zip(symbols, values))
+
+            result = self.plc.write_list_of_symbols(symbols_with_data)
+
+            self.assertEqual(result, ['no error'] * 3)
+
+            for i, symbol in enumerate(symbols):
+                real_value = symbol.read()
+                self.assertEqual(real_value, values[i])
 
 
 if __name__ == "__main__":

--- a/tests/test_connection_class.py
+++ b/tests/test_connection_class.py
@@ -1039,7 +1039,10 @@ class AdsConnectionClassTestCase(unittest.TestCase):
 
         # Read twice to show caching
         with self.plc:
-            read_values = self.plc.read_list_by_name(variables)
+            # New, combined method:
+            read_values = self.plc.read_list(variables)
+
+            # Old, direct method:
             read_values2 = self.plc.read_list_by_name(variables)
 
         # Retrieve list of received requests from server
@@ -1141,8 +1144,11 @@ class AdsConnectionClassTestCase(unittest.TestCase):
         }
 
         with self.plc:
+            # Use old, direct method:
             errors = self.plc.write_list_by_name(variables, cache_symbol_info=False)
-            errors2 = self.plc.write_list_by_name(variables)
+
+            # Use new, combined method:
+            errors2 = self.plc.write_list(variables)
 
         # Retrieve list of received requests from server
         requests = self.test_server.request_history
@@ -1507,7 +1513,7 @@ class ConnectionSymbolListTestCase(unittest.TestCase):
         with self.plc:
             symbols = [AdsSymbol(self.plc, name=var.name) for var in self.vars]
 
-            result = self.plc.read_list_of_symbols(symbols)
+            result = self.plc.read_list(symbols)
 
         expected = {"Double1": 3.14, "Double2": 1.54, "Int1": 420}
         self.assertEqual(expected, result)
@@ -1525,7 +1531,7 @@ class ConnectionSymbolListTestCase(unittest.TestCase):
             values = [16.16, 25.55, 53]
             symbols_with_data = dict(zip(symbols, values))
 
-            result = self.plc.write_list_of_symbols(symbols_with_data)
+            result = self.plc.write_list(symbols_with_data)
 
             expected = {"Double1": "no error", "Double2": "no error", "Int1": "no error"}
             self.assertEqual(expected, result)

--- a/tests/test_connection_class.py
+++ b/tests/test_connection_class.py
@@ -1527,7 +1527,8 @@ class ConnectionSymbolListTestCase(unittest.TestCase):
 
             result = self.plc.write_list_of_symbols(symbols_with_data)
 
-            self.assertEqual(result, ['no error'] * 3)
+            expected = {"Double1": "no error", "Double2": "no error", "Int1": "no error"}
+            self.assertEqual(expected, result)
 
             for i, symbol in enumerate(symbols):
                 real_value = symbol.read()


### PR DESCRIPTION
Replacement for the faulty:
- #268 

Fixes #266 

This adds the option to read multiple symbols at once, or write to multiple at once.

Unfortunately this is not directly compatible with `adsSumRead` and `adsSumWrite` (assuming we don't want the redundant info lookup when using only the name).
This is because those functions are based on the `SAdsSymbolInfo` structs, which contain the integer `dataType`, instead of a ctypes like `plc_type`.

I've tried to move some of the logic to separate functions so they can be reused, but the new symbol read/write methods resemble the classic functions a lot.

Example script:

```
from pyads import Connection
from random import random

plc = Connection('127.0.0.1.1.1', 851)

with plc:

    var_names = [
        "GVL.my_double",
        "GVL.another_double",
        "GVL.my_text",
        # "GVL.my_list"
    ]

    symbols = [plc.get_symbol(var) for var in var_names]

    new_data = [random(), random(), "Hello again"]

    data_with_names = dict(zip(var_names, new_data))

    # response = plc.write_list_by_name(data_with_names)
    # print(response)

    response = plc.write_list_symbols(symbols, new_data)
    print(response)

    # data = plc.read_list_by_name(var_names)
    # print(data)

    result = plc.read_list_symbols(symbols, True)
    print(result)

    for symbol in symbols:
        print(symbol.name + ":", symbol.value)

```