### PR TITLE
Add runtime typed ADS type system with self-contained tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ deploy
 coverage
 .mypy_cache/
 .pytest_cache/
+tests/live_ads_config.json
 
 # vscode files
 .vscode/

--- a/src/pyads/__init__.py
+++ b/src/pyads/__init__.py
@@ -118,4 +118,6 @@ from .constants import (
 
 from .symbol import AdsSymbol
 
+from .typed_symbols import TypeSystem, TypedSymbolTable
+
 __version__ = '3.6.0.dev1'

--- a/src/pyads/connection.py
+++ b/src/pyads/connection.py
@@ -5,7 +5,9 @@
 :created on: 2018-06-11 18:15:53
 
 """
+
 from __future__ import annotations
+
 import struct
 from ctypes import (
     memmove,
@@ -126,6 +128,7 @@ class Connection(object):
         self.ams_net_port = ams_net_port
         self._notifications = {}  # type: Dict[int, str]
         self._symbol_info_cache: Dict[str, SAdsSymbolEntry] = {}
+        self._type_system_cache = None
 
     @property
     def ams_netid(self) -> str:
@@ -488,6 +491,30 @@ class Connection(object):
                                    symbol_type=symbol_type, comment=comment)
                 symbols.append(symbol)
         return symbols
+
+    def get_type_system(self, refresh: bool = False, debug: bool = False) -> "TypeSystem":
+        """Return a runtime type system for ADS symbols and datatypes.
+
+        The type system is built from ``ADSIGRP_SYM_UPLOAD`` and
+        ``ADSIGRP_SYM_DT_UPLOAD`` and cached on the connection. It is read-only
+        and does not change existing symbol APIs.
+
+        :param bool refresh: rebuild the cached type system when True
+        :param bool debug: enable debug logging while uploading/parsing
+        :return: TypeSystem with symbols, datatypes, schema, and typed reads
+        """
+        if self._port is None:
+            raise ValueError("Cannot build type system with a closed Connection")
+        if refresh or self._type_system_cache is None:
+            from .typed_symbols import TypeSystem
+
+            self._type_system_cache = TypeSystem.from_connection(self, debug=debug)
+        return self._type_system_cache
+
+    def get_typed_symbol_table(self) -> "TypedSymbolTable":
+        """Backward-compatible alias for :meth:`get_type_system`."""
+
+        return self.get_type_system()
 
     def get_handle(self, data_name: str) -> Optional[int]:
         """Get the handle of the PLC-variable, handles obtained using this

--- a/src/pyads/testserver/advanced_handler.py
+++ b/src/pyads/testserver/advanced_handler.py
@@ -203,6 +203,10 @@ class AdvancedHandler(AbstractHandler):
 
     def __init__(self) -> None:
         self._data: Dict[Tuple[int, int], PLCVariable] = {}
+        self._symbol_upload_blob: Optional[bytes] = None
+        self._datatype_upload_blob: Optional[bytes] = None
+        self._symbol_upload_count: int = 0
+        self._datatype_upload_count: int = 0
         # This will be our variables database
         # We won't both with indexing it by handle or name, speed is not
         # important. We store by group + offset index and will have to
@@ -213,6 +217,45 @@ class AdvancedHandler(AbstractHandler):
     def reset(self) -> None:
         """Clear saved variables in handler"""
         self._data = {}
+        self._symbol_upload_blob = None
+        self._datatype_upload_blob = None
+        self._symbol_upload_count = 0
+        self._datatype_upload_count = 0
+
+    @staticmethod
+    def _count_entries(blob: bytes, minimum_entry_size: int = 4) -> int:
+        """Count ADS entries in a length-prefixed blob."""
+        count = 0
+        pos = 0
+        end = len(blob)
+        while pos + minimum_entry_size <= end:
+            entry_length = struct.unpack_from("<I", blob, pos)[0]
+            if entry_length <= 0 or pos + entry_length > end:
+                break
+            count += 1
+            pos += entry_length
+        return count
+
+    def configure_symbol_upload(
+        self,
+        symbol_blob: bytes,
+        datatype_blob: bytes = b"",
+        symbol_count: Optional[int] = None,
+        datatype_count: Optional[int] = None,
+    ) -> None:
+        """Configure deterministic symbol/datatype upload responses."""
+        self._symbol_upload_blob = bytes(symbol_blob or b"")
+        self._datatype_upload_blob = bytes(datatype_blob or b"")
+        self._symbol_upload_count = (
+            symbol_count
+            if symbol_count is not None
+            else self._count_entries(self._symbol_upload_blob, minimum_entry_size=30)
+        )
+        self._datatype_upload_count = (
+            datatype_count
+            if datatype_count is not None
+            else self._count_entries(self._datatype_upload_blob, minimum_entry_size=40)
+        )
 
     def handle_request(self, request: AmsPacket) -> AmsResponseData:
         """Handle incoming requests and create a response."""
@@ -260,15 +303,44 @@ class AdvancedHandler(AbstractHandler):
                 response_value = self.get_variable_by_handle(index_offset).value
 
             elif index_group == constants.ADSIGRP_SYM_UPLOADINFO2:
-                symbol_count = len(self._data)
-                response_length = 120 * symbol_count
-                response_value = struct.pack("II", symbol_count, response_length)
+                if self._symbol_upload_blob is not None:
+                    response_value = struct.pack(
+                        "<IIIIII",
+                        self._symbol_upload_count,
+                        len(self._symbol_upload_blob),
+                        self._datatype_upload_count,
+                        len(self._datatype_upload_blob or b""),
+                        0,
+                        0,
+                    )
+                else:
+                    symbol_count = len(self._data)
+                    response_length = 120 * symbol_count
+                    response_value = struct.pack("<II", symbol_count, response_length)
+
+            elif index_group == constants.ADSIGRP_SYM_UPLOADINFO:
+                if self._symbol_upload_blob is not None:
+                    response_value = struct.pack(
+                        "<II",
+                        self._symbol_upload_count,
+                        len(self._symbol_upload_blob),
+                    )
+                else:
+                    symbol_count = len(self._data)
+                    response_length = 120 * symbol_count
+                    response_value = struct.pack("<II", symbol_count, response_length)
 
             elif index_group == constants.ADSIGRP_SYM_UPLOAD:
-                response_value = b""
-                for (group, offset) in self._data.keys():
-                    response_value += struct.pack("III", 120, group, offset)
-                    response_value += b"\x00" * 108
+                if self._symbol_upload_blob is not None:
+                    response_value = self._symbol_upload_blob
+                else:
+                    response_value = b""
+                    for (group, offset) in self._data.keys():
+                        response_value += struct.pack("<III", 120, group, offset)
+                        response_value += b"\x00" * 108
+
+            elif index_group == constants.ADSIGRP_SYM_DT_UPLOAD:
+                response_value = self._datatype_upload_blob or b""
 
             else:
                 # Create response of repeated 0x0F with a null

--- a/src/pyads/testserver/testserver.py
+++ b/src/pyads/testserver/testserver.py
@@ -20,6 +20,7 @@ from __future__ import absolute_import
 from typing import Any, List, Type, Optional
 from types import TracebackType
 import atexit
+import os
 import select
 import socket
 import struct
@@ -45,14 +46,19 @@ class AdsTestServer(threading.Thread):
             self,
             handler: "AbstractHandler" = None,
             ip_address: str = "127.0.0.1",
-            port: int = ADS_PORT,
+            port: Optional[int] = None,
             logging: bool = True,
             *args: Any,
             **kwargs: Any,
     ) -> None:
         self.handler = handler or BasicHandler()
         self.ip_address = ip_address
-        self.port = port
+        configured_port = (
+            int(os.environ.get("PYADS_TESTSERVER_PORT", ADS_PORT))
+            if port is None
+            else int(port)
+        )
+        self.port = configured_port
         self._run = True
 
         global logger
@@ -67,7 +73,14 @@ class AdsTestServer(threading.Thread):
         # Set option to allow instant socket reuse after shutdown
         self.server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
-        self.server.bind((self.ip_address, self.port))
+        try:
+            self.server.bind((self.ip_address, self.port))
+        except OSError as exc:
+            raise OSError(
+                "Could not bind AdsTestServer to {}:{} ({})".format(
+                    self.ip_address, self.port, exc
+                )
+            ) from exc
 
         # Make sure we clean up on exit
         atexit.register(self.close)

--- a/src/pyads/typed_symbols.py
+++ b/src/pyads/typed_symbols.py
@@ -1,0 +1,1010 @@
+"""Runtime ADS symbol and datatype support.
+
+This module reads the TwinCAT symbol table and datatype table, builds a
+runtime type system from both blobs, and decodes read-only values without a
+hand-written ``structure_def``.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import struct
+from collections import OrderedDict, defaultdict
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, Iterator, List, Mapping, Optional, Tuple
+
+from .constants import (
+    ADSIGRP_SYM_DT_UPLOAD,
+    ADSIGRP_SYM_UPLOAD,
+    ADSIGRP_SYM_UPLOADINFO,
+    ADSIGRP_SYM_UPLOADINFO2,
+    ADSIGRP_SYM_VALBYHND,
+    ADSIOFFS_DEVDATA_ADSSTATE,
+    MAX_ADS_SUB_COMMANDS,
+)
+from .pyads_ex import adsSumReadBytes
+from .structs import ctypes
+
+LOG = logging.getLogger(__name__)
+
+
+ADS_DTFLG_DATATYPE = 0x00000001
+ADS_DTFLG_DATAITEM = 0x00000002
+ADS_DTFLG_REFERENCETO = 0x00000004
+ADS_DTFLG_BITVALUES = 0x00000020
+ADS_DTFLG_PROPITEM = 0x00000040
+ADS_DTFLG_TYPEGUID = 0x00000080
+ADS_DTFLG_ATTRIBUTES = 0x00001000
+ADS_DTFLG_ENUMINFOS = 0x00002000
+ADS_DTFLG_ALIGNED = 0x00010000
+ADS_DTFLG_STATIC = 0x00020000
+ADS_DTFLG_IGNOREPERSIST = 0x00080000
+ADS_DTFLG_ANYSIZEARRAY = 0x00100000
+ADS_DTFLG_PLCPOINTERTYPE = 0x00800000
+ADS_DTFLG_HIDESUBITEMS = 0x02000000
+ADS_DTFLG_INCOMPLETE = 0x04000000
+ADS_DTFLG_EXTENUMINFOS = 0x20000000
+
+MAX_ARRAY_ELEMENTS = 4096
+
+
+@dataclass(frozen=True)
+class SymbolEntry:
+    """One entry from ``ADSIGRP_SYM_UPLOAD``."""
+
+    name: str
+    type_name: str
+    comment: str
+    index_group: int
+    index_offset: int
+    size: int
+    data_type: int
+    flags: int
+
+    @property
+    def typeName(self) -> str:
+        """Compatibility alias used by earlier local prototypes."""
+
+        return self.type_name
+
+    @property
+    def iGroup(self) -> int:
+        """Compatibility alias used by earlier local prototypes."""
+
+        return self.index_group
+
+    @property
+    def iOffs(self) -> int:
+        """Compatibility alias used by earlier local prototypes."""
+
+        return self.index_offset
+
+    @property
+    def dataType(self) -> int:
+        """Compatibility alias used by earlier local prototypes."""
+
+        return self.data_type
+
+
+@dataclass
+class TypeAttribute:
+    name: str
+    value: str = ""
+
+
+@dataclass
+class DataTypeEntry:
+    """One ``AdsDatatypeEntry`` including nested subitems."""
+
+    entry_length: int
+    version: int
+    hash_value: int
+    type_hash_value: int
+    size: int
+    offset: int
+    data_type: int
+    flags: int
+    name: str
+    type_name: str
+    comment: str
+    array_info: List[Tuple[int, int]] = field(default_factory=list)
+    subitems: List["DataTypeEntry"] = field(default_factory=list)
+    attributes: List[TypeAttribute] = field(default_factory=list)
+
+    @property
+    def offs(self) -> int:
+        """Compatibility alias used by earlier local prototypes."""
+
+        return self.offset
+
+    @property
+    def dataType(self) -> int:
+        """Compatibility alias used by earlier local prototypes."""
+
+        return self.data_type
+
+    @property
+    def typeName(self) -> str:
+        """Compatibility alias used by earlier local prototypes."""
+
+        return self.type_name
+
+    @property
+    def arrayInfo(self) -> List[Tuple[int, int]]:
+        """Compatibility alias used by earlier local prototypes."""
+
+        return self.array_info
+
+    @property
+    def subItems(self) -> int:
+        """Compatibility alias used by earlier local prototypes."""
+
+        return len(self.subitems)
+
+    @property
+    def subs(self) -> List["DataTypeEntry"]:
+        """Compatibility alias used by earlier local prototypes."""
+
+        return self.subitems
+
+    @property
+    def is_array(self) -> bool:
+        return bool(self.array_info)
+
+    @property
+    def is_pointer_or_reference(self) -> bool:
+        decl = (self.name or "").upper()
+        typ = (self.type_name or "").upper()
+        return (
+            "POINTER TO " in decl
+            or "REFERENCE TO " in decl
+            or "POINTER TO " in typ
+            or "REFERENCE TO " in typ
+            or bool(self.flags & (ADS_DTFLG_REFERENCETO | ADS_DTFLG_PLCPOINTERTYPE))
+        )
+
+
+def _le_u16(blob: bytes, offset: int) -> Tuple[int, int]:
+    return struct.unpack_from("<H", blob, offset)[0], offset + 2
+
+
+def _le_u32(blob: bytes, offset: int) -> Tuple[int, int]:
+    return struct.unpack_from("<I", blob, offset)[0], offset + 4
+
+
+def _decode_tc_string(data: bytes) -> str:
+    return data.decode("windows-1252", errors="ignore")
+
+
+def _read_len_string(blob: bytes, offset: int, length: int) -> Tuple[str, int]:
+    data = blob[offset : offset + length]
+    return _decode_tc_string(data), offset + length + 1
+
+
+def _looks_text(data: bytes) -> bool:
+    return bool(data) and all((32 <= c < 127) or c in (9, 10, 13) for c in data)
+
+
+def _scan_attributes(tail: bytes) -> List[TypeAttribute]:
+    """Best-effort parser for TwinCAT datatype attribute tails."""
+
+    if len(tail) < 2:
+        return []
+
+    def parse_counted(start: int, width: int) -> Optional[List[TypeAttribute]]:
+        if start + width > len(tail):
+            return None
+        count = int.from_bytes(tail[start : start + width], "little")
+        if count <= 0 or count > 256:
+            return None
+        pos = start + width
+        attrs: List[TypeAttribute] = []
+        for _ in range(count):
+            if pos + width > len(tail):
+                return None
+            name_len = int.from_bytes(tail[pos : pos + width], "little")
+            pos += width
+            if name_len > 4096 or pos + name_len + 1 > len(tail):
+                return None
+            name = tail[pos : pos + name_len]
+            pos += name_len + 1
+
+            if pos + width > len(tail):
+                return None
+            value_len = int.from_bytes(tail[pos : pos + width], "little")
+            pos += width
+            if value_len > 65535 or pos + value_len + 1 > len(tail):
+                return None
+            value = tail[pos : pos + value_len]
+            pos += value_len + 1
+
+            if not _looks_text(name):
+                return None
+            attrs.append(
+                TypeAttribute(_decode_tc_string(name), _decode_tc_string(value))
+            )
+        return attrs
+
+    def parse_cstrings(start: int) -> Optional[List[TypeAttribute]]:
+        pos = start
+        strings: List[str] = []
+        while pos < len(tail):
+            end = tail.find(b"\x00", pos)
+            if end < 0:
+                break
+            raw = tail[pos:end]
+            pos = end + 1
+            if not raw:
+                continue
+            if not _looks_text(raw):
+                return None
+            strings.append(_decode_tc_string(raw))
+        if not strings:
+            return None
+        attrs = []
+        it = iter(strings)
+        for name in it:
+            attrs.append(TypeAttribute(name, next(it, "")))
+        return attrs
+
+    for start in range(min(64, len(tail))):
+        for parser in (
+            lambda pos: parse_counted(pos, 2),
+            lambda pos: parse_counted(pos, 4),
+            parse_cstrings,
+        ):
+            parsed = parser(start)
+            if parsed:
+                return parsed
+    return []
+
+
+def parse_symbols(blob: bytes) -> List[SymbolEntry]:
+    """Parse a raw symbol table blob."""
+
+    symbols: List[SymbolEntry] = []
+    pos = 0
+    end = len(blob)
+    while pos + 30 <= end:
+        entry_length, cursor = _le_u32(blob, pos)
+        if entry_length <= 0 or entry_length > end - pos:
+            break
+        index_group, cursor = _le_u32(blob, cursor)
+        index_offset, cursor = _le_u32(blob, cursor)
+        size, cursor = _le_u32(blob, cursor)
+        data_type, cursor = _le_u32(blob, cursor)
+        flags, cursor = _le_u32(blob, cursor)
+        name_len, cursor = _le_u16(blob, cursor)
+        type_len, cursor = _le_u16(blob, cursor)
+        comment_len, cursor = _le_u16(blob, cursor)
+
+        name, cursor = _read_len_string(blob, cursor, name_len)
+        type_name, cursor = _read_len_string(blob, cursor, type_len)
+        comment, _ = _read_len_string(blob, cursor, comment_len)
+
+        symbols.append(
+            SymbolEntry(
+                name=name,
+                type_name=type_name,
+                comment=comment,
+                index_group=index_group,
+                index_offset=index_offset,
+                size=size,
+                data_type=data_type,
+                flags=flags,
+            )
+        )
+        pos += entry_length
+    return symbols
+
+
+def _parse_datatype_entry(blob: bytes, offset: int) -> Tuple[DataTypeEntry, int]:
+    start = offset
+    if offset + 4 > len(blob):
+        raise StopIteration
+    entry_length, offset = _le_u32(blob, offset)
+    if entry_length <= 0 or start + entry_length > len(blob):
+        raise StopIteration
+
+    version, offset = _le_u32(blob, offset)
+    hash_value, offset = _le_u32(blob, offset)
+    type_hash_value, offset = _le_u32(blob, offset)
+    size, offset = _le_u32(blob, offset)
+    item_offset, offset = _le_u32(blob, offset)
+    data_type, offset = _le_u32(blob, offset)
+    flags, offset = _le_u32(blob, offset)
+    name_length, offset = _le_u16(blob, offset)
+    type_length, offset = _le_u16(blob, offset)
+    comment_length, offset = _le_u16(blob, offset)
+    array_dim, offset = _le_u16(blob, offset)
+    subitem_count, offset = _le_u16(blob, offset)
+
+    name, offset = _read_len_string(blob, offset, name_length)
+    type_name, offset = _read_len_string(blob, offset, type_length)
+    comment, offset = _read_len_string(blob, offset, comment_length)
+
+    array_info: List[Tuple[int, int]] = []
+    for _ in range(array_dim):
+        lower_bound, offset = _le_u32(blob, offset)
+        elements, offset = _le_u32(blob, offset)
+        array_info.append((lower_bound, elements))
+
+    subitems: List[DataTypeEntry] = []
+    cursor = offset
+    for _ in range(subitem_count):
+        subitem, cursor = _parse_datatype_entry(blob, cursor)
+        subitems.append(subitem)
+
+    end = start + entry_length
+    tail = blob[cursor:end] if cursor < end else b""
+    attributes = _scan_attributes(tail) if flags & ADS_DTFLG_ATTRIBUTES else []
+
+    return (
+        DataTypeEntry(
+            entry_length=entry_length,
+            version=version,
+            hash_value=hash_value,
+            type_hash_value=type_hash_value,
+            size=size,
+            offset=item_offset,
+            data_type=data_type,
+            flags=flags,
+            name=name,
+            type_name=type_name,
+            comment=comment,
+            array_info=array_info,
+            subitems=subitems,
+            attributes=attributes,
+        ),
+        end,
+    )
+
+
+def parse_datatypes(blob: Optional[bytes]) -> List[DataTypeEntry]:
+    """Parse raw datatype table bytes into an ordered list of entries."""
+
+    if not blob:
+        return []
+
+    def parse_from(start: int) -> List[DataTypeEntry]:
+        entries: List[DataTypeEntry] = []
+        offset = start
+        while offset + 4 <= len(blob):
+            try:
+                entry, offset = _parse_datatype_entry(blob, offset)
+            except StopIteration:
+                break
+            entries.append(entry)
+        return entries
+
+    entries = parse_from(0)
+    if entries:
+        return entries
+    for start in range(1, min(64, len(blob))):
+        entries = parse_from(start)
+        if entries:
+            return entries
+    return []
+
+
+def parse_dtypes(blob: Optional[bytes]) -> Dict[str, DataTypeEntry]:
+    """Compatibility parser returning the preferred type lookup map."""
+
+    return _build_type_maps(parse_datatypes(blob))[0]
+
+
+def _is_type_declaration_key(name: str) -> bool:
+    upper = (name or "").upper()
+    return not (
+        upper.startswith("POINTER TO ")
+        or upper.startswith("REFERENCE TO ")
+        or upper.startswith("ARRAY ")
+    )
+
+
+def _build_type_maps(
+    entries: Iterable[DataTypeEntry],
+) -> Tuple[Dict[str, DataTypeEntry], Dict[str, DataTypeEntry], Dict[str, DataTypeEntry]]:
+    by_key: Dict[str, DataTypeEntry] = {}
+    by_declaration: Dict[str, DataTypeEntry] = {}
+    aliases: Dict[str, DataTypeEntry] = {}
+
+    for entry in entries:
+        if entry.name:
+            by_declaration.setdefault(entry.name, entry)
+            if _is_type_declaration_key(entry.name):
+                by_key.setdefault(entry.name, entry)
+        if entry.type_name:
+            if entry.name and entry.name != entry.type_name and _is_type_declaration_key(entry.name):
+                aliases.setdefault(entry.name, entry)
+            if entry.name == entry.type_name:
+                by_key.setdefault(entry.type_name, entry)
+
+    for alias, entry in aliases.items():
+        by_key.setdefault(alias, entry)
+    return by_key, by_declaration, aliases
+
+
+def _raw_value(type_name: str, data: bytes, reason: str) -> Dict[str, Any]:
+    return {
+        "__ads_type__": type_name,
+        "__raw__": data.hex(),
+        "__reason__": reason,
+    }
+
+
+def _decode_scalar(type_name: str, data: bytes, offset: int, size: int) -> Tuple[Any, int]:
+    type_upper = (type_name or "").strip().upper()
+    chunk_end = offset + max(0, size)
+    try:
+        if type_upper == "BOOL":
+            return data[offset] != 0, offset + 1
+        if type_upper in ("BYTE", "USINT"):
+            return data[offset], offset + 1
+        if type_upper == "SINT":
+            return struct.unpack_from("<b", data, offset)[0], offset + 1
+        if type_upper == "INT":
+            return struct.unpack_from("<h", data, offset)[0], offset + 2
+        if type_upper in ("UINT", "WORD"):
+            return struct.unpack_from("<H", data, offset)[0], offset + 2
+        if type_upper == "DINT":
+            return struct.unpack_from("<i", data, offset)[0], offset + 4
+        if type_upper in ("UDINT", "DWORD"):
+            return struct.unpack_from("<I", data, offset)[0], offset + 4
+        if type_upper == "LINT":
+            return struct.unpack_from("<q", data, offset)[0], offset + 8
+        if type_upper in ("ULINT", "LWORD"):
+            return struct.unpack_from("<Q", data, offset)[0], offset + 8
+        if type_upper == "REAL":
+            return struct.unpack_from("<f", data, offset)[0], offset + 4
+        if type_upper == "LREAL":
+            return struct.unpack_from("<d", data, offset)[0], offset + 8
+        if type_upper.startswith("STRING"):
+            raw = data[offset:chunk_end]
+            nul = raw.find(b"\x00")
+            if nul >= 0:
+                raw = raw[:nul]
+            return _decode_tc_string(raw), chunk_end
+        if type_upper.startswith("WSTRING"):
+            raw = data[offset:chunk_end]
+            return raw.decode("utf-16-le", errors="ignore").split("\x00", 1)[0], chunk_end
+        if type_upper in (
+            "TIME",
+            "TIME_OF_DAY",
+            "TOD",
+            "DATE",
+            "DT",
+            "DATE_AND_TIME",
+            "LTIME",
+            "LTOD",
+            "LDT",
+        ):
+            if size == 8:
+                return struct.unpack_from("<Q", data, offset)[0], offset + 8
+            if size == 4:
+                return struct.unpack_from("<I", data, offset)[0], offset + 4
+            return int.from_bytes(data[offset:chunk_end], "little"), chunk_end
+    except (IndexError, struct.error):
+        return None, offset
+    return None, offset
+
+
+def _decode_address(data: bytes, offset: int, size: int) -> int:
+    end = offset + max(0, size)
+    if size >= 8:
+        return struct.unpack_from("<Q", data, offset)[0]
+    if size >= 4:
+        return struct.unpack_from("<I", data, offset)[0]
+    return int.from_bytes(data[offset:end], "little")
+
+
+def _product(values: Iterable[int]) -> int:
+    result = 1
+    for value in values:
+        result *= max(0, value)
+    return result
+
+
+def _split_path(path: str) -> List[str]:
+    return [part for part in re.split(r"\.(?![^\[]*\])", path) if part]
+
+
+class TypeSystem:
+    """Symbols, datatypes, schema metadata, and read-only typed decoders."""
+
+    def __init__(
+        self,
+        symbols: List[SymbolEntry],
+        datatypes: Optional[List[DataTypeEntry]] = None,
+    ) -> None:
+        self.symbols = symbols
+        self.datatypes = datatypes or []
+        self._symbols_by_name = {symbol.name: symbol for symbol in self.symbols}
+        self.types, self.declarations, self.aliases = _build_type_maps(self.datatypes)
+        self.dt_map = self.types
+
+    @classmethod
+    def from_blobs(
+        cls,
+        symbol_blob: bytes,
+        datatype_blob: Optional[bytes] = None,
+        *,
+        debug: bool = False,
+    ) -> "TypeSystem":
+        if debug:
+            LOG.setLevel(logging.DEBUG)
+        return cls(parse_symbols(symbol_blob or b""), parse_datatypes(datatype_blob))
+
+    @classmethod
+    def from_connection(cls, plc: Any, *, debug: bool = False) -> "TypeSystem":
+        symbol_blob, datatype_blob = upload_symbol_and_datatype_blobs(plc, debug=debug)
+        return cls.from_blobs(symbol_blob, datatype_blob, debug=debug)
+
+    def iter_symbols(self, prefix: Optional[str] = None) -> Iterator[SymbolEntry]:
+        if not prefix:
+            return iter(self.symbols)
+        dotted_prefix = prefix + "."
+        return (
+            symbol
+            for symbol in self.symbols
+            if symbol.name == prefix or symbol.name.startswith(dotted_prefix)
+        )
+
+    def get_symbol(self, name: str) -> Optional[SymbolEntry]:
+        return self._symbols_by_name.get(name)
+
+    def get_type(self, type_name: str) -> Optional[DataTypeEntry]:
+        return self.types.get(type_name) or self.declarations.get(type_name)
+
+    def to_schema(self) -> Dict[str, Any]:
+        return {
+            "symbols": [self._symbol_to_schema(symbol) for symbol in self.symbols],
+            "types": {
+                name: self._datatype_to_schema(entry)
+                for name, entry in sorted(self.types.items())
+            },
+            "declarations": {
+                name: self._datatype_to_schema(entry)
+                for name, entry in sorted(self.declarations.items())
+                if name not in self.types
+            },
+        }
+
+    def read_value(self, plc: Any, name: str) -> Any:
+        symbol = self._require_symbol(name)
+        raw = self._read_symbol_raw(plc, symbol)
+        return self.decode_value(symbol.type_name, raw, 0, symbol.size)
+
+    def read_tree(self, plc: Any, root: str) -> Any:
+        return self.read_value(plc, root)
+
+    def read_values(
+        self,
+        plc: Any,
+        names: Iterable[str],
+        *,
+        batch: bool = True,
+        ads_sub_commands: int = MAX_ADS_SUB_COMMANDS,
+    ) -> Dict[str, Any]:
+        names_list = list(names)
+        if not batch:
+            return {name: self._read_path(plc, name) for name in names_list}
+
+        groups: Dict[str, List[str]] = defaultdict(list)
+        direct_symbols: List[SymbolEntry] = []
+        for name in names_list:
+            symbol = self.get_symbol(name)
+            if symbol is not None:
+                direct_symbols.append(symbol)
+                continue
+            root = self._find_root_symbol_name(name)
+            if root is None:
+                raise KeyError("Symbol not found: {}".format(name))
+            groups[root].append(name)
+
+        result: Dict[str, Any] = {}
+        if direct_symbols:
+            raw_by_name = self._sum_read_raw(plc, direct_symbols, ads_sub_commands)
+            for symbol in direct_symbols:
+                result[symbol.name] = self.decode_value(
+                    symbol.type_name, raw_by_name[symbol.name], 0, symbol.size
+                )
+
+        for root, requested_paths in groups.items():
+            root_symbol = self._require_symbol(root)
+            raw = self._read_symbol_raw(plc, root_symbol)
+            decoded_root = self.decode_value(root_symbol.type_name, raw, 0, root_symbol.size)
+            for requested_path in requested_paths:
+                rel_path = requested_path[len(root) :].lstrip(".")
+                result[requested_path] = self._extract_decoded_path(decoded_root, rel_path)
+        return result
+
+    def decode_value(
+        self,
+        type_name: str,
+        data: bytes,
+        offset: int = 0,
+        size: Optional[int] = None,
+        _stack: Optional[List[str]] = None,
+    ) -> Any:
+        total_size = len(data) - offset if size is None else max(0, size)
+        raw = data[offset : offset + total_size]
+        type_name = (type_name or "").strip()
+
+        scalar, next_offset = _decode_scalar(type_name, data, offset, total_size)
+        if scalar is not None or next_offset != offset:
+            return scalar
+
+        if "POINTER TO " in type_name.upper() or "REFERENCE TO " in type_name.upper():
+            return {
+                "__ads_type__": type_name,
+                "__address__": _decode_address(data, offset, total_size),
+                "__reason__": "pointer_or_reference",
+            }
+
+        datatype = self.get_type(type_name)
+        if datatype is None:
+            return _raw_value(type_name, raw, "unknown_type")
+
+        return self._decode_datatype(datatype, data, offset, total_size, _stack or [])
+
+    def _decode_datatype(
+        self,
+        datatype: DataTypeEntry,
+        data: bytes,
+        offset: int,
+        size: int,
+        stack: List[str],
+    ) -> Any:
+        key = datatype.name or datatype.type_name
+        raw = data[offset : offset + size]
+        if key in stack:
+            return _raw_value(key, raw, "recursive_type")
+        if datatype.flags & ADS_DTFLG_INCOMPLETE:
+            return _raw_value(key, raw, "incomplete_type")
+        if datatype.flags & ADS_DTFLG_HIDESUBITEMS:
+            return _raw_value(key, raw, "hidden_subitems")
+        if datatype.is_pointer_or_reference:
+            return {
+                "__ads_type__": datatype.name or datatype.type_name,
+                "__address__": _decode_address(data, offset, size),
+                "__reason__": "pointer_or_reference",
+            }
+
+        if datatype.array_info:
+            return self._decode_array(datatype, data, offset, size, stack + [key])
+
+        if datatype.subitems:
+            result: "OrderedDict[str, Any]" = OrderedDict()
+            for subitem in datatype.subitems:
+                sub_size = subitem.size or max(0, size - subitem.offset)
+                sub_offset = offset + subitem.offset
+                result[subitem.name] = self._decode_subitem(
+                    subitem, data, sub_offset, sub_size, stack + [key]
+                )
+            return result
+
+        scalar_type = datatype.type_name or datatype.name
+        scalar, next_offset = _decode_scalar(scalar_type, data, offset, size)
+        if scalar is not None or next_offset != offset:
+            return scalar
+
+        if datatype.flags & (ADS_DTFLG_ENUMINFOS | ADS_DTFLG_EXTENUMINFOS | ADS_DTFLG_BITVALUES):
+            return int.from_bytes(raw, "little", signed=False)
+
+        if datatype.type_name and datatype.type_name != datatype.name:
+            alias_target = self.get_type(datatype.type_name)
+            if alias_target is not None and alias_target is not datatype:
+                return self._decode_datatype(alias_target, data, offset, size, stack + [key])
+
+        return _raw_value(datatype.name or datatype.type_name, raw, "opaque_type")
+
+    def _decode_subitem(
+        self,
+        subitem: DataTypeEntry,
+        data: bytes,
+        offset: int,
+        size: int,
+        stack: List[str],
+    ) -> Any:
+        if subitem.subitems or subitem.array_info or not subitem.type_name:
+            return self._decode_datatype(subitem, data, offset, size, stack)
+        return self.decode_value(subitem.type_name, data, offset, size, stack)
+
+    def _decode_array(
+        self,
+        datatype: DataTypeEntry,
+        data: bytes,
+        offset: int,
+        size: int,
+        stack: List[str],
+    ) -> List[Any]:
+        counts = [elements for _, elements in datatype.array_info]
+        element_count = _product(counts)
+        if element_count <= 0:
+            return []
+        total_size = size or datatype.size
+        element_size = max(1, total_size // element_count)
+        element_type = datatype.type_name
+        if datatype.subitems and datatype.subitems[0].type_name:
+            element_type = datatype.subitems[0].type_name
+
+        decoded: List[Any] = []
+        decode_count = min(element_count, MAX_ARRAY_ELEMENTS)
+        for index in range(decode_count):
+            item_offset = offset + index * element_size
+            if item_offset + element_size > offset + total_size:
+                break
+            decoded.append(self.decode_value(element_type, data, item_offset, element_size, stack))
+        if decode_count < element_count:
+            decoded.append(
+                _raw_value(
+                    datatype.name or datatype.type_name,
+                    b"",
+                    "truncated_array_{}_of_{}".format(decode_count, element_count),
+                )
+            )
+        return decoded
+
+    def _read_path(self, plc: Any, name: str) -> Any:
+        symbol = self.get_symbol(name)
+        if symbol is not None:
+            return self.read_value(plc, name)
+        root = self._find_root_symbol_name(name)
+        if root is None:
+            raise KeyError("Symbol not found: {}".format(name))
+        root_value = self.read_tree(plc, root)
+        return self._extract_decoded_path(root_value, name[len(root) :].lstrip("."))
+
+    def _find_root_symbol_name(self, name: str) -> Optional[str]:
+        parts = _split_path(name)
+        for index in range(len(parts), 0, -1):
+            candidate = ".".join(parts[:index])
+            if candidate in self._symbols_by_name:
+                return candidate
+        return None
+
+    def _require_symbol(self, name: str) -> SymbolEntry:
+        symbol = self.get_symbol(name)
+        if symbol is None:
+            raise KeyError("Symbol not found: {}".format(name))
+        return symbol
+
+    def _read_symbol_raw(self, plc: Any, symbol: SymbolEntry) -> bytes:
+        try:
+            return read_raw_block(plc, symbol.index_group, symbol.index_offset, symbol.size)
+        except Exception:
+            handle = plc.get_handle(symbol.name)
+            try:
+                raw_type = ctypes.c_ubyte * symbol.size
+                return bytes(
+                    plc.read(
+                        ADSIGRP_SYM_VALBYHND,
+                        handle,
+                        raw_type,
+                        return_ctypes=True,
+                        check_length=False,
+                    )
+                )
+            finally:
+                plc.release_handle(handle)
+
+    def _sum_read_raw(
+        self,
+        plc: Any,
+        symbols: List[SymbolEntry],
+        ads_sub_commands: int,
+    ) -> Dict[str, bytes]:
+        if not symbols:
+            return {}
+        if getattr(plc, "_port", None) is None:
+            return {symbol.name: self._read_symbol_raw(plc, symbol) for symbol in symbols}
+
+        result: Dict[str, bytes] = {}
+        for start in range(0, len(symbols), ads_sub_commands):
+            chunk = symbols[start : start + ads_sub_commands]
+            requests = [
+                (symbol.index_group, symbol.index_offset, symbol.size) for symbol in chunk
+            ]
+            response = adsSumReadBytes(plc._port, plc._adr, requests)
+            payload_offset = 4 * len(chunk)
+            for index, symbol in enumerate(chunk):
+                error = struct.unpack_from("<I", response, index * 4)[0]
+                if error:
+                    raise RuntimeError(
+                        "ADS SumRead failed for {} with error {}".format(
+                            symbol.name, error
+                        )
+                    )
+                result[symbol.name] = bytes(
+                    response[payload_offset : payload_offset + symbol.size]
+                )
+                payload_offset += symbol.size
+        return result
+
+    def _extract_decoded_path(self, value: Any, rel_path: str) -> Any:
+        current = value
+        for part in _split_path(rel_path):
+            name, indexes = self._parse_part_indexes(part)
+            if name:
+                if not isinstance(current, Mapping) or name not in current:
+                    raise KeyError("Path component not found: {}".format(part))
+                current = current[name]
+            for index in indexes:
+                if not isinstance(current, list):
+                    raise KeyError("Path component is not an array: {}".format(part))
+                current = current[index]
+        return current
+
+    @staticmethod
+    def _parse_part_indexes(part: str) -> Tuple[str, List[int]]:
+        match = re.match(r"^([^\[]+)((?:\[[^\]]+\])*)$", part)
+        if not match:
+            return part, []
+        name = match.group(1)
+        raw_indexes = match.group(2)
+        indexes = []
+        for raw in re.findall(r"\[([^\]]+)\]", raw_indexes):
+            for value in raw.split(","):
+                indexes.append(int(value))
+        return name, indexes
+
+    @staticmethod
+    def _symbol_to_schema(symbol: SymbolEntry) -> Dict[str, Any]:
+        return {
+            "name": symbol.name,
+            "type": symbol.type_name,
+            "comment": symbol.comment,
+            "index_group": symbol.index_group,
+            "index_offset": symbol.index_offset,
+            "size": symbol.size,
+            "data_type": symbol.data_type,
+            "flags": symbol.flags,
+        }
+
+    def _datatype_to_schema(self, datatype: DataTypeEntry) -> Dict[str, Any]:
+        return {
+            "name": datatype.name,
+            "type": datatype.type_name,
+            "comment": datatype.comment,
+            "size": datatype.size,
+            "offset": datatype.offset,
+            "data_type": datatype.data_type,
+            "flags": datatype.flags,
+            "array_info": [
+                {"lower_bound": lower, "elements": elements}
+                for lower, elements in datatype.array_info
+            ],
+            "attributes": [
+                {"name": attr.name, "value": attr.value} for attr in datatype.attributes
+            ],
+            "subitems": [
+                self._datatype_to_schema(subitem) for subitem in datatype.subitems
+            ],
+        }
+
+
+class TypedSymbolTable(TypeSystem):
+    """Backward-compatible name for earlier local experiments."""
+
+
+def build_typed_symbol_table(
+    symbol_block_bytes: bytes,
+    n_symbols: int = 0,
+    datatype_block_bytes: Optional[bytes] = None,
+    n_datatypes: int = 0,
+) -> TypedSymbolTable:
+    table = TypedSymbolTable(
+        parse_symbols(symbol_block_bytes or b""),
+        parse_datatypes(datatype_block_bytes),
+    )
+    if n_symbols and n_symbols != len(table.symbols):
+        LOG.debug("Symbol count mismatch: upload=%s parsed=%s", n_symbols, len(table.symbols))
+    if n_datatypes and n_datatypes != len(table.datatypes):
+        LOG.debug(
+            "Datatype count mismatch: upload=%s parsed=%s",
+            n_datatypes,
+            len(table.datatypes),
+        )
+    return table
+
+
+def read_raw_block(plc: Any, index_group: int, index_offset: int, size: int) -> bytes:
+    raw_type = ctypes.c_ubyte * size
+    return bytes(
+        plc.read(
+            index_group,
+            index_offset,
+            raw_type,
+            return_ctypes=True,
+            check_length=False,
+        )
+    )
+
+
+def _read_upload_info(plc: Any, debug: bool = False) -> Tuple[int, int, int, int]:
+    raw_type = ctypes.c_ubyte * 24
+    errors: List[Exception] = []
+    for index_offset in (0, ADSIOFFS_DEVDATA_ADSSTATE):
+        try:
+            raw = bytes(
+                plc.read(
+                    ADSIGRP_SYM_UPLOADINFO2,
+                    index_offset,
+                    raw_type,
+                    return_ctypes=True,
+                    check_length=False,
+                )
+            )
+            if len(raw) >= 16:
+                n_symbols, symbol_size, n_datatypes, datatype_size = struct.unpack_from(
+                    "<IIII", raw, 0
+                )
+                if debug:
+                    LOG.debug(
+                        "UPLOADINFO2 offset=%s symbols=%s sym_size=%s datatypes=%s dt_size=%s",
+                        index_offset,
+                        n_symbols,
+                        symbol_size,
+                        n_datatypes,
+                        datatype_size,
+                    )
+                return n_symbols, symbol_size, n_datatypes, datatype_size
+        except Exception as exc:
+            errors.append(exc)
+
+    legacy_type = ctypes.c_ubyte * 8
+    for index_offset in (0, ADSIOFFS_DEVDATA_ADSSTATE):
+        try:
+            raw = bytes(
+                plc.read(
+                    ADSIGRP_SYM_UPLOADINFO,
+                    index_offset,
+                    legacy_type,
+                    return_ctypes=True,
+                    check_length=False,
+                )
+            )
+            if len(raw) >= 8:
+                n_symbols, symbol_size = struct.unpack_from("<II", raw, 0)
+                return n_symbols, symbol_size, 0, 0
+        except Exception as exc:
+            errors.append(exc)
+
+    if errors:
+        raise RuntimeError("Could not read ADS symbol upload info") from errors[-1]
+    raise RuntimeError("Could not read ADS symbol upload info")
+
+
+def upload_symbol_and_datatype_blobs(
+    plc: Any,
+    *,
+    debug: bool = False,
+) -> Tuple[bytes, bytes]:
+    """Upload raw symbol and datatype blobs from an open connection."""
+
+    _n_symbols, symbol_size, _n_datatypes, datatype_size = _read_upload_info(
+        plc, debug=debug
+    )
+    symbol_blob = _read_blob_with_offsets(plc, ADSIGRP_SYM_UPLOAD, symbol_size)
+    datatype_blob = b""
+    if datatype_size:
+        try:
+            datatype_blob = _read_blob_with_offsets(plc, ADSIGRP_SYM_DT_UPLOAD, datatype_size)
+        except Exception:
+            LOG.debug("Datatype upload failed", exc_info=True)
+            datatype_blob = b""
+    return symbol_blob, datatype_blob
+
+
+def _read_blob_with_offsets(plc: Any, index_group: int, size: int) -> bytes:
+    last_error: Optional[Exception] = None
+    for index_offset in (0, ADSIOFFS_DEVDATA_ADSSTATE):
+        try:
+            return read_raw_block(plc, index_group, index_offset, size)
+        except Exception as exc:
+            last_error = exc
+    raise RuntimeError(
+        "Could not read ADS blob index_group=0x{:X} size={}".format(index_group, size)
+    ) from last_error

--- a/tests/live_ads_config.example.json
+++ b/tests/live_ads_config.example.json
@@ -1,0 +1,8 @@
+{
+  "device": "Beckhoff CX (example)",
+  "ams_net_id": "1.2.3.4.1.1",
+  "ams_port": 851,
+  "reported_ads_port": 28678,
+  "ip_address": "192.168.0.10",
+  "root_symbol": "MAIN.someRoot"
+}

--- a/tests/test_connection_class.py
+++ b/tests/test_connection_class.py
@@ -52,8 +52,11 @@ class AdsConnectionClassTestCase(unittest.TestCase):
     def setUpClass(cls):
         # type: () -> None
         """Setup the ADS testserver."""
-        cls.test_server = AdsTestServer(logging=False)
-        cls.test_server.start()
+        try:
+            cls.test_server = AdsTestServer(logging=False)
+            cls.test_server.start()
+        except OSError as exc:
+            raise unittest.SkipTest(str(exc))
 
         # wait a bit otherwise error might occur
         time.sleep(1)
@@ -1299,8 +1302,11 @@ class AdsApiTestCaseAdvanced(unittest.TestCase):
     def setUpClass(cls):
         # Start dummy ADS Endpoint
         cls.handler = AdvancedHandler()
-        cls.test_server = AdsTestServer(handler=cls.handler, logging=False)
-        cls.test_server.start()
+        try:
+            cls.test_server = AdsTestServer(handler=cls.handler, logging=False)
+            cls.test_server.start()
+        except OSError as exc:
+            raise unittest.SkipTest(str(exc))
 
         # wait a bit otherwise error might occur
         time.sleep(1)

--- a/tests/test_plc_ams.py
+++ b/tests/test_plc_ams.py
@@ -13,6 +13,16 @@ class PLCAMSTestCase(unittest.TestCase):
     PLC_IP = "127.0.0.1"
     PLC_AMS_ID = "11.22.33.44.1.1"
 
+    @staticmethod
+    def _require_udp_port() -> None:
+        with closing(socket.socket(socket.AF_INET, socket.SOCK_DGRAM)) as sock:
+            try:
+                sock.bind(("", PORT_REMOTE_UDP))
+            except OSError as exc:
+                raise unittest.SkipTest(
+                    "UDP port {} unavailable: {}".format(PORT_REMOTE_UDP, exc)
+                )
+
     def plc_ams_request_receiver(self):
         with closing(socket.socket(socket.AF_INET, socket.SOCK_DGRAM)) as sock:
             sock.bind(("", PORT_REMOTE_UDP))
@@ -36,6 +46,7 @@ class PLCAMSTestCase(unittest.TestCase):
             sock.sendto(response, addr)
 
     def test_get_ams(self):
+        self._require_udp_port()
         # Start receiving listener
         route_thread = threading.Thread(target=self.plc_ams_request_receiver, daemon=True)
         route_thread.start()

--- a/tests/test_plc_route.py
+++ b/tests/test_plc_route.py
@@ -26,6 +26,16 @@ class PLCRouteTestCase(unittest.TestCase):
     def tearDown(self):
         pass
 
+    @staticmethod
+    def _require_udp_port() -> None:
+        with closing(socket.socket(socket.AF_INET, socket.SOCK_DGRAM)) as sock:
+            try:
+                sock.bind(("", PORT_REMOTE_UDP))
+            except OSError as exc:
+                raise unittest.SkipTest(
+                    "UDP port {} unavailable: {}".format(PORT_REMOTE_UDP, exc)
+                )
+
     def plc_route_receiver(self):
         with closing(socket.socket(socket.AF_INET, socket.SOCK_DGRAM)) as sock:
             sock.bind(("", PORT_REMOTE_UDP))
@@ -153,6 +163,7 @@ class PLCRouteTestCase(unittest.TestCase):
 
     def test_correct_route(self):
         if platform_is_linux():
+            self._require_udp_port()
             # Start receiving listener
             route_thread = threading.Thread(target=self.plc_route_receiver, daemon=True)
             route_thread.start()
@@ -177,6 +188,7 @@ class PLCRouteTestCase(unittest.TestCase):
 
     def test_incorrect_route(self):
         if platform_is_linux():
+            self._require_udp_port()
             # Start receiving listener
             route_thread = threading.Thread(target=self.plc_route_receiver, daemon=True)
             route_thread.start()

--- a/tests/test_symbol.py
+++ b/tests/test_symbol.py
@@ -33,8 +33,11 @@ class AdsSymbolTestCase(unittest.TestCase):
         # type: () -> None
         """Setup the ADS test server."""
         cls.handler = AdvancedHandler()
-        cls.test_server = AdsTestServer(handler=cls.handler, logging=False)
-        cls.test_server.start()
+        try:
+            cls.test_server = AdsTestServer(handler=cls.handler, logging=False)
+            cls.test_server.start()
+        except OSError as exc:
+            raise unittest.SkipTest(str(exc))
 
         # wait a bit otherwise error might occur
         time.sleep(1)

--- a/tests/test_testserver.py
+++ b/tests/test_testserver.py
@@ -25,9 +25,16 @@ class TestServerTestCase(unittest.TestCase):
     case is only for a few items that were left uncovered.
     """
 
+    @staticmethod
+    def _create_server_or_skip(handler):
+        try:
+            return AdsTestServer(handler=handler, logging=False)
+        except OSError as exc:
+            raise unittest.SkipTest(str(exc))
+
     def test_start_stop(self):
         handler = BasicHandler()
-        test_server = AdsTestServer(handler=handler, logging=False)
+        test_server = self._create_server_or_skip(handler)
         test_server.start()
         time.sleep(0.1)  # Give server a moment to spin up
         test_server.stop()
@@ -35,7 +42,7 @@ class TestServerTestCase(unittest.TestCase):
 
     def test_context(self):
         handler = BasicHandler()
-        test_server = AdsTestServer(handler=handler, logging=False)
+        test_server = self._create_server_or_skip(handler)
 
         with test_server:
 
@@ -55,7 +62,7 @@ class TestServerTestCase(unittest.TestCase):
         """
         # 1. spin up the server
         handler = BasicHandler()
-        test_server = AdsTestServer(handler=handler, logging=False)
+        test_server = self._create_server_or_skip(handler)
         test_server.start()
         time.sleep(0.1)  # Give server a moment to spin up
 

--- a/tests/test_typed_symbols.py
+++ b/tests/test_typed_symbols.py
@@ -1,0 +1,433 @@
+import struct
+import time
+import unittest
+
+import pyads
+from pyads import constants
+from pyads.testserver import AdsTestServer, AdvancedHandler, PLCVariable
+from pyads.typed_symbols import DataTypeEntry, SymbolEntry, TypeSystem
+
+
+def _pack_len_string(value: str) -> bytes:
+    return value.encode("windows-1252") + b"\x00"
+
+
+def _pack_symbol_entry(
+    name: str,
+    type_name: str,
+    index_group: int,
+    index_offset: int,
+    size: int,
+    data_type: int,
+    flags: int = 0,
+    comment: str = "",
+) -> bytes:
+    name_b = name.encode("windows-1252")
+    type_b = type_name.encode("windows-1252")
+    comment_b = comment.encode("windows-1252")
+    entry_length = 30 + len(name_b) + 1 + len(type_b) + 1 + len(comment_b) + 1
+    return (
+        struct.pack(
+            "<IIIIIIHHH",
+            entry_length,
+            index_group,
+            index_offset,
+            size,
+            data_type,
+            flags,
+            len(name_b),
+            len(type_b),
+            len(comment_b),
+        )
+        + _pack_len_string(name)
+        + _pack_len_string(type_name)
+        + _pack_len_string(comment)
+    )
+
+
+def _pack_datatype_entry(
+    *,
+    name: str,
+    type_name: str,
+    size: int,
+    offset: int = 0,
+    data_type: int = constants.ADST_BIGTYPE,
+    flags: int = 0,
+    comment: str = "",
+    subitems: list[bytes] | None = None,
+    array_info: list[tuple[int, int]] | None = None,
+) -> bytes:
+    subitems = subitems or []
+    array_info = array_info or []
+
+    name_b = name.encode("windows-1252")
+    type_b = type_name.encode("windows-1252")
+    comment_b = comment.encode("windows-1252")
+
+    header = struct.pack(
+        "<IIIIIIIIHHHHH",
+        0,  # entry length placeholder
+        1,  # version
+        0,  # hash
+        0,  # type hash
+        size,
+        offset,
+        data_type,
+        flags,
+        len(name_b),
+        len(type_b),
+        len(comment_b),
+        len(array_info),
+        len(subitems),
+    )
+
+    body = _pack_len_string(name) + _pack_len_string(type_name) + _pack_len_string(comment)
+    for lower_bound, elements in array_info:
+        body += struct.pack("<II", lower_bound, elements)
+    body += b"".join(subitems)
+
+    entry = header + body
+    return struct.pack("<I", len(entry)) + entry[4:]
+
+
+def _build_test_blobs() -> tuple[bytes, bytes]:
+    sensor_type = _pack_datatype_entry(
+        name="TECH_TempSensor",
+        type_name="TECH_TempSensor",
+        size=36,
+        subitems=[
+            _pack_datatype_entry(
+                name="temperature",
+                type_name="REAL",
+                size=4,
+                offset=0,
+                data_type=constants.ADST_REAL32,
+            ),
+            _pack_datatype_entry(
+                name="valid",
+                type_name="BOOL",
+                size=1,
+                offset=4,
+                data_type=constants.ADST_BIT,
+            ),
+        ],
+    )
+    sensor_pointer_decl = _pack_datatype_entry(
+        name="POINTER TO TECH_TempSensor",
+        type_name="POINTER TO TECH_TempSensor",
+        size=4,
+        data_type=constants.ADST_UINT32,
+        flags=0x00800000,
+    )
+    heizung_type = _pack_datatype_entry(
+        name="FB_Heizung",
+        type_name="FB_Heizung",
+        size=8,
+        subitems=[
+            _pack_datatype_entry(
+                name="Enable",
+                type_name="BOOL",
+                size=1,
+                offset=0,
+                data_type=constants.ADST_BIT,
+            ),
+            _pack_datatype_entry(
+                name="Sollwert",
+                type_name="REAL",
+                size=4,
+                offset=4,
+                data_type=constants.ADST_REAL32,
+            ),
+        ],
+    )
+
+    datatype_blob = sensor_type + sensor_pointer_decl + heizung_type
+    symbol_blob = (
+        _pack_symbol_entry(
+            name="MAIN.heizung",
+            type_name="FB_Heizung",
+            index_group=constants.INDEXGROUP_DATA,
+            index_offset=1000,
+            size=8,
+            data_type=constants.ADST_BIGTYPE,
+        )
+        + _pack_symbol_entry(
+            name="MAIN.tempSensorPtr",
+            type_name="POINTER TO TECH_TempSensor",
+            index_group=constants.INDEXGROUP_DATA,
+            index_offset=1010,
+            size=4,
+            data_type=constants.ADST_UINT32,
+        )
+    )
+    return symbol_blob, datatype_blob
+
+
+def _load_fixture_type_system():
+    symbol_blob, datatype_blob = _build_test_blobs()
+    return TypeSystem.from_blobs(symbol_blob, datatype_blob)
+
+
+class TestTypedSymbolsFixtures(unittest.TestCase):
+    def test_fixture_symbol_and_datatype_counts(self):
+        ts = _load_fixture_type_system()
+
+        self.assertEqual(len(ts.symbols), 2)
+        self.assertEqual(len(ts.datatypes), 3)
+
+    def test_fixture_main_heizung_type(self):
+        ts = _load_fixture_type_system()
+
+        symbol = ts.get_symbol("MAIN.heizung")
+        self.assertIsNotNone(symbol)
+        self.assertEqual(symbol.type_name, "FB_Heizung")
+        self.assertEqual(symbol.size, 8)
+
+        datatype = ts.get_type("FB_Heizung")
+        self.assertIsNotNone(datatype)
+        self.assertEqual(datatype.size, 8)
+        self.assertEqual(len(datatype.subitems), 2)
+
+    def test_pointer_declarations_do_not_override_concrete_type(self):
+        ts = _load_fixture_type_system()
+
+        datatype = ts.get_type("TECH_TempSensor")
+        self.assertIsNotNone(datatype)
+        self.assertEqual(datatype.name, "TECH_TempSensor")
+        self.assertEqual(datatype.size, 36)
+        self.assertGreater(len(datatype.subitems), 0)
+
+
+class TestTypedSymbolsDecoder(unittest.TestCase):
+    def test_decode_scalar_and_string_values(self):
+        ts = TypeSystem([], [])
+
+        self.assertEqual(ts.decode_value("INT", struct.pack("<h", -12)), -12)
+        self.assertAlmostEqual(
+            ts.decode_value("REAL", struct.pack("<f", 12.5)),
+            12.5,
+        )
+        self.assertEqual(ts.decode_value("STRING(10)", b"hello\x00xxxxx"), "hello")
+        self.assertEqual(
+            ts.decode_value("WSTRING(10)", "abc".encode("utf-16-le") + b"\x00\x00"),
+            "abc",
+        )
+
+    def test_decode_struct_from_subitem_offsets(self):
+        datatype = DataTypeEntry(
+            entry_length=0,
+            version=0,
+            hash_value=0,
+            type_hash_value=0,
+            size=8,
+            offset=0,
+            data_type=65,
+            flags=0,
+            name="SampleStruct",
+            type_name="",
+            comment="",
+            subitems=[
+                DataTypeEntry(
+                    entry_length=0,
+                    version=0,
+                    hash_value=0,
+                    type_hash_value=0,
+                    size=2,
+                    offset=0,
+                    data_type=2,
+                    flags=0,
+                    name="counter",
+                    type_name="INT",
+                    comment="",
+                ),
+                DataTypeEntry(
+                    entry_length=0,
+                    version=0,
+                    hash_value=0,
+                    type_hash_value=0,
+                    size=4,
+                    offset=4,
+                    data_type=4,
+                    flags=0,
+                    name="value",
+                    type_name="REAL",
+                    comment="",
+                ),
+            ],
+        )
+        ts = TypeSystem([], [datatype])
+        raw = struct.pack("<hxxf", 7, 3.25)
+
+        decoded = ts.decode_value("SampleStruct", raw)
+
+        self.assertEqual(decoded["counter"], 7)
+        self.assertAlmostEqual(decoded["value"], 3.25)
+
+    def test_decode_array_values(self):
+        datatype = DataTypeEntry(
+            entry_length=0,
+            version=0,
+            hash_value=0,
+            type_hash_value=0,
+            size=6,
+            offset=0,
+            data_type=2,
+            flags=0,
+            name="ARRAY [1..3] OF INT",
+            type_name="INT",
+            comment="",
+            array_info=[(1, 3)],
+        )
+        ts = TypeSystem([], [datatype])
+        raw = struct.pack("<hhh", 1, 2, 3)
+
+        self.assertEqual(ts.decode_value("ARRAY [1..3] OF INT", raw), [1, 2, 3])
+
+    def test_decode_pointer_as_opaque_address(self):
+        ts = TypeSystem([], [])
+        decoded = ts.decode_value("POINTER TO INT", struct.pack("<I", 0x12345678))
+
+        self.assertEqual(decoded["__address__"], 0x12345678)
+        self.assertEqual(decoded["__reason__"], "pointer_or_reference")
+
+
+class FakePlc:
+    _port = None
+
+    def __init__(self, values):
+        self.values = values
+        self.reads = []
+
+    def read(self, index_group, index_offset, plc_datatype, **_kwargs):
+        self.reads.append((index_group, index_offset))
+        payload = self.values[(index_group, index_offset)]
+        return plc_datatype(*payload)
+
+
+class TestTypedSymbolsBatchRead(unittest.TestCase):
+    def test_read_values_reads_direct_symbols(self):
+        symbols = [
+            SymbolEntry("a", "INT", "", 1, 0, 2, 2, 0),
+            SymbolEntry("b", "INT", "", 1, 2, 2, 2, 0),
+        ]
+        plc = FakePlc({(1, 0): struct.pack("<h", 10), (1, 2): struct.pack("<h", 20)})
+        ts = TypeSystem(symbols, [])
+
+        self.assertEqual(ts.read_values(plc, ["a", "b"]), {"a": 10, "b": 20})
+        self.assertEqual(plc.reads, [(1, 0), (1, 2)])
+
+    def test_read_values_groups_subpaths_by_root_symbol(self):
+        symbol = SymbolEntry("Root", "SampleStruct", "", 1, 0, 8, 65, 0)
+        datatype = DataTypeEntry(
+            entry_length=0,
+            version=0,
+            hash_value=0,
+            type_hash_value=0,
+            size=8,
+            offset=0,
+            data_type=65,
+            flags=0,
+            name="SampleStruct",
+            type_name="",
+            comment="",
+            subitems=[
+                DataTypeEntry(
+                    entry_length=0,
+                    version=0,
+                    hash_value=0,
+                    type_hash_value=0,
+                    size=2,
+                    offset=0,
+                    data_type=2,
+                    flags=0,
+                    name="counter",
+                    type_name="INT",
+                    comment="",
+                ),
+                DataTypeEntry(
+                    entry_length=0,
+                    version=0,
+                    hash_value=0,
+                    type_hash_value=0,
+                    size=4,
+                    offset=4,
+                    data_type=4,
+                    flags=0,
+                    name="value",
+                    type_name="REAL",
+                    comment="",
+                ),
+            ],
+        )
+        plc = FakePlc({(1, 0): struct.pack("<hxxf", 7, 3.25)})
+        ts = TypeSystem([symbol], [datatype])
+
+        result = ts.read_values(plc, ["Root.counter", "Root.value"])
+
+        self.assertEqual(result["Root.counter"], 7)
+        self.assertAlmostEqual(result["Root.value"], 3.25)
+        self.assertEqual(plc.reads, [(1, 0)])
+
+
+class TestTypedSymbolsWithTestserver(unittest.TestCase):
+    TEST_SERVER_AMS_NET_ID = "127.0.0.1.1.1"
+    TEST_SERVER_IP_ADDRESS = "127.0.0.1"
+    TEST_SERVER_AMS_PORT = pyads.PORT_SPS1
+
+    @classmethod
+    def setUpClass(cls):
+        cls.handler = AdvancedHandler()
+        symbol_blob, datatype_blob = _build_test_blobs()
+        cls.handler.configure_symbol_upload(symbol_blob, datatype_blob)
+
+        cls.handler.add_variable(
+            PLCVariable(
+                "MAIN.heizung",
+                b"\x01\x00\x00\x00" + struct.pack("<f", 21.5),
+                constants.ADST_BIGTYPE,
+                "FB_Heizung",
+                index_group=constants.INDEXGROUP_DATA,
+                index_offset=1000,
+            )
+        )
+
+        try:
+            cls.test_server = AdsTestServer(handler=cls.handler, logging=False)
+        except OSError as exc:
+            raise unittest.SkipTest(str(exc))
+        cls.test_server.start()
+        time.sleep(0.3)
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "test_server"):
+            cls.test_server.stop()
+            time.sleep(0.2)
+
+    def test_get_type_system_from_testserver_fixtures(self):
+        with pyads.Connection(
+            self.TEST_SERVER_AMS_NET_ID,
+            self.TEST_SERVER_AMS_PORT,
+            self.TEST_SERVER_IP_ADDRESS,
+        ) as plc:
+            ts = plc.get_type_system(refresh=True)
+
+            self.assertEqual(len(ts.symbols), 2)
+            self.assertEqual(len(ts.datatypes), 3)
+            self.assertEqual(ts.get_symbol("MAIN.heizung").type_name, "FB_Heizung")
+
+    def test_read_tree_from_testserver_fixture_symbol(self):
+        with pyads.Connection(
+            self.TEST_SERVER_AMS_NET_ID,
+            self.TEST_SERVER_AMS_PORT,
+            self.TEST_SERVER_IP_ADDRESS,
+        ) as plc:
+            ts = plc.get_type_system(refresh=True)
+            decoded = ts.read_tree(plc, "MAIN.heizung")
+
+            self.assertIsInstance(decoded, dict)
+            self.assertEqual(decoded["Enable"], True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_typed_symbols_live.py
+++ b/tests/test_typed_symbols_live.py
@@ -1,0 +1,112 @@
+import json
+import os
+from pathlib import Path
+from typing import Any, Mapping
+
+import pytest
+
+import pyads
+
+
+CONFIG_PATH = Path(__file__).with_name("live_ads_config.json")
+
+
+def _live_enabled():
+    return os.environ.get("PYADS_RUN_LIVE", "").lower() in {"1", "true", "yes", "on"}
+
+
+def _load_live_config():
+    file_config = {}
+    if CONFIG_PATH.exists():
+        file_config = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+
+    return {
+        "device": os.environ.get("PYADS_LIVE_DEVICE", file_config.get("device", "")),
+        "ams_net_id": os.environ.get(
+            "PYADS_LIVE_AMS", file_config.get("ams_net_id", "")
+        ),
+        "ams_port": int(
+            os.environ.get("PYADS_LIVE_PORT", file_config.get("ams_port", 851))
+        ),
+        "ip_address": os.environ.get(
+            "PYADS_LIVE_IP", file_config.get("ip_address", "")
+        ),
+        "root_symbol": os.environ.get(
+            "PYADS_LIVE_ROOT", file_config.get("root_symbol", "MAIN.heizung")
+        ),
+    }
+
+
+def _find_leaf_path(value: Any, prefix: str = "") -> str:
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            if str(key).startswith("__"):
+                continue
+            child_prefix = "{}.{}".format(prefix, key) if prefix else str(key)
+            leaf = _find_leaf_path(item, child_prefix)
+            if leaf:
+                return leaf
+        return ""
+    if isinstance(value, list):
+        if not value:
+            return ""
+        child_prefix = "{}[0]".format(prefix) if prefix else "[0]"
+        return _find_leaf_path(value[0], child_prefix)
+    return prefix
+
+
+pytestmark = pytest.mark.skipif(
+    not _live_enabled(),
+    reason="live ADS tests require PYADS_RUN_LIVE=1",
+)
+
+
+def test_live_type_system_upload_and_root_decode():
+    config = _load_live_config()
+    assert config["ams_net_id"], "ams_net_id missing"
+    assert config["ip_address"], "ip_address missing"
+
+    with pyads.Connection(
+        config["ams_net_id"],
+        config["ams_port"],
+        config["ip_address"],
+    ) as plc:
+        type_system = plc.get_type_system(refresh=True, debug=True)
+
+        assert len(type_system.symbols) > 0
+        assert len(type_system.datatypes) > 0
+
+        root = config["root_symbol"]
+        root_symbol = type_system.get_symbol(root)
+        assert root_symbol is not None
+        assert root_symbol.size > 0
+
+        decoded = type_system.read_tree(plc, root)
+        assert decoded is not None
+
+
+def test_live_batch_read_root_and_leaf():
+    config = _load_live_config()
+    root = config["root_symbol"]
+
+    with pyads.Connection(
+        config["ams_net_id"],
+        config["ams_port"],
+        config["ip_address"],
+    ) as plc:
+        type_system = plc.get_type_system(refresh=True)
+        decoded_root = type_system.read_tree(plc, root)
+        rel_leaf = _find_leaf_path(decoded_root)
+        if not rel_leaf:
+            pytest.skip("no leaf path found under live root symbol")
+
+        if rel_leaf.startswith("["):
+            leaf = root + rel_leaf
+        else:
+            leaf = root + "." + rel_leaf
+
+        values = type_system.read_values(plc, [root, leaf], batch=True)
+
+        assert root in values
+        assert leaf in values
+        assert values[leaf] == type_system._extract_decoded_path(decoded_root, rel_leaf)


### PR DESCRIPTION
## Summary

This PR adds a read-only runtime typed ADS layer that can build a type system from ADS symbol and datatype uploads and decode complex PLC values without requiring hand-written `structure_def`.

It introduces a new `TypeSystem` API and integrates it into `Connection`, with backward-compatible aliasing.

## What is included

- New module: `src/pyads/typed_symbols.py`
  - Upload helpers for symbol/datatype blobs (`ADSIGRP_SYM_UPLOAD`, `ADSIGRP_SYM_UPLOADINFO2`, fallback to `ADSIGRP_SYM_UPLOADINFO`, `ADSIGRP_SYM_DT_UPLOAD`)
  - Symbol/datatype parsers
  - Runtime type lookup maps (type names, declarations, aliases)
  - Read-only decoder for:
    - Scalars
    - `STRING` / `WSTRING`
    - Structs / FBs via subitem offsets
    - Arrays (incl. multidimensional)
    - Pointer/reference values as opaque addresses (no dereference)
    - Unknown/recursive/incomplete/hidden types as opaque raw payloads
  - Batch read strategy (`read_values(..., batch=True)`) with root grouping and sum-read support

- `Connection` API additions (`src/pyads/connection.py`)
  - `get_type_system(refresh=False, debug=False)`
  - `get_typed_symbol_table()` (compatibility alias)

- Public exports (`src/pyads/__init__.py`)
  - `TypeSystem`
  - `TypedSymbolTable`

- Testserver improvements
  - `src/pyads/testserver/advanced_handler.py`
    - fixture-style symbol/datatype upload responses for:
      - `SYM_UPLOADINFO2`
      - `SYM_UPLOADINFO`
      - `SYM_UPLOAD`
      - `SYM_DT_UPLOAD`
  - `src/pyads/testserver/testserver.py`
    - configurable port via `PYADS_TESTSERVER_PORT`
    - clearer bind errors

- Tests
  - `tests/test_typed_symbols.py` (self-contained, no binary fixture files required)
  - `tests/test_typed_symbols_live.py` (optional live tests, gated by `PYADS_RUN_LIVE=1`)
  - Existing tests hardened to skip cleanly when local fixed ports are unavailable:
    - `tests/test_connection_class.py`
    - `tests/test_symbol.py`
    - `tests/test_testserver.py`
    - `tests/test_plc_ams.py`
    - `tests/test_plc_route.py`
  - Local config template:
    - `tests/live_ads_config.example.json`
  - Local live config ignored:
    - `.gitignore` adds `tests/live_ads_config.json`

## Validation

Executed locally:

- `PYTHONPATH=src python -m pytest tests/test_typed_symbols.py tests/test_typed_symbols_live.py -q`
  - `9 passed, 4 skipped`
- `PYTHONPATH=src PYADS_RUN_LIVE=1 python -m pytest tests/test_typed_symbols_live.py -q`
  - `2 passed`

(plus targeted testserver/UDP-related tests with expected skip behavior on blocked local ports)

## Notes

- Scope is intentionally **read-only** typed ADS support.
- Typed write support and higher-level integrations (e.g. Home Assistant discovery/config workflows) are out of scope for this PR.
