### PR TITLE
ci: introduce RISC-V runner to matrix

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         # macos-15-intel is an Intel runner, macos-14 is Apple silicon
-        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm, macos-15-intel, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, ubuntu-24.04-riscv, windows-latest, windows-11-arm, macos-15-intel, macos-latest]
 
     steps:
       - uses: actions/checkout@v5
@@ -64,7 +64,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-15-intel, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, ubuntu-24.04-riscv, macos-15-intel, macos-latest]
         # Can't really test with Windows because 'TcAdsDll.dll' will be missing
 
     steps:


### PR DESCRIPTION
Introduce RISC-V runner to matrix, depends on RISE RISC-V Runner community runner add-on from GitHub marketplace. Adds wheels build, test, and publish for riscv64 architecture.

Depends: stlehmann/pyads#521
Resolves: stlehmann/pyads#520