### PR TITLE
CI: Fix segmentation faults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 

--- a/src/pyads/pyads_ex.py
+++ b/src/pyads/pyads_ex.py
@@ -1383,7 +1383,7 @@ def adsSyncDelDeviceNotificationReqEx(
     pAmsAddr = ctypes.pointer(adr.amsAddrStruct())
     nHNotification = ctypes.c_ulong(notification_handle)
     err_code = adsSyncDelDeviceNotificationReqFct(port, pAmsAddr, nHNotification)
-    del callback_store[(adr, notification_handle)]
+    callback_store.pop((adr, notification_handle), None)
     if err_code:
         raise ADSError(err_code)
 

--- a/src/pyads/pyads_ex.py
+++ b/src/pyads/pyads_ex.py
@@ -6,6 +6,7 @@
 
 """
 from typing import Union, Callable, Any, Tuple, Type, Optional, List, Dict
+import atexit
 import ctypes
 import os
 import platform
@@ -123,6 +124,10 @@ else:  # pragma: no cover, can not test unsupported platform
     raise RuntimeError("Unsupported platform {0}.".format(sys.platform))
 
 callback_store: Dict[Tuple[AmsAddr, int], Callable[[SAmsAddr, SAdsNotificationHeader, int], None]] = dict()
+
+# Clear callback_store at interpreter shutdown before ctypes tears down the C
+# library, preventing segfaults from dangling function-pointer references.
+atexit.register(callback_store.clear)
 
 
 class ADSError(Exception):

--- a/src/pyads/pyads_ex.py
+++ b/src/pyads/pyads_ex.py
@@ -6,7 +6,6 @@
 
 """
 from typing import Union, Callable, Any, Tuple, Type, Optional, List, Dict
-import atexit
 import ctypes
 import os
 import platform
@@ -124,10 +123,6 @@ else:  # pragma: no cover, can not test unsupported platform
     raise RuntimeError("Unsupported platform {0}.".format(sys.platform))
 
 callback_store: Dict[Tuple[AmsAddr, int], Callable[[SAmsAddr, SAdsNotificationHeader, int], None]] = dict()
-
-# Clear callback_store at interpreter shutdown before ctypes tears down the C
-# library, preventing segfaults from dangling function-pointer references.
-atexit.register(callback_store.clear)
 
 
 class ADSError(Exception):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import faulthandler
+
+# Emit a Python traceback on segfault instead of a silent crash.
+# This helps diagnose any remaining shutdown-time segfaults from the C library.
+faulthandler.enable()


### PR DESCRIPTION
Hopefully resolves #524. It should at least make it easier to find the root cause by enabling tracebacks on silent crashes.

- disable fail-fast to allow all versions of Python to run even if one shows a fault
- use pop on callack_store instead of deleting the objects
- enable faulthandler for tests to emit meaningful tracebacks on silent crashes