### PR TITLE
CI: Fix Segmentation error on module shutdown

### DIFF
--- a/src/pyads/connection.py
+++ b/src/pyads/connection.py
@@ -6,6 +6,7 @@
 
 """
 from __future__ import annotations
+import sys
 import struct
 from ctypes import (
     memmove,
@@ -165,6 +166,8 @@ class Connection(object):
 
         Make sure to close the connection when an instance runs out of scope.
         """
+        if sys.is_finalizing():
+            return
         # If the connection is already closed, nothing new will happen
         self.close()
 


### PR DESCRIPTION
Resolves #524 

fix: skip adsPortCloseEx in Connection.__del__ during interpreter shutdown

When Connection objects are GC'd during Python interpreter shutdown, calling AdsPortCloseEx via adslib.so crashes (SIGSEGV / exit 139) because the ADS routing layer is already torn down. Guard __del__ with sys.is_finalizing() so the C library is not called during this phase; the OS reclaims sockets and file descriptors regardless.