### PR TITLE
Bump version to 3.6.0.dev2

### DIFF
--- a/src/pyads/__init__.py
+++ b/src/pyads/__init__.py
@@ -118,4 +118,4 @@ from .constants import (
 
 from .symbol import AdsSymbol
 
-__version__ = '3.6.0.dev1'
+__version__ = '3.6.0.dev2'


### PR DESCRIPTION
Bumps `__version__` to `3.6.0.dev2` to prepare a new prerelease build.

Ref #505

A new prerelease built from current `master` will include the adslib submodule update (`d5a950d`, based on Beckhoff/ADS commit `e0e559c`), which fixes the `AdsNotificationHeader` field order. The published `3.6.0.dev1` wheel was built before that fix and has a struct layout mismatch with `SAdsNotificationHeader` in `structs.py`, causing the garbled/static notification timestamps reported in #505. Rebuilding from `master` under this new version number should resolve that issue.