### PR TITLE
ci: temporarily disable ubuntu-24.04-riscv runner

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         # macos-15-intel is an Intel runner, macos-14 is Apple silicon
-        os: [ubuntu-latest, ubuntu-24.04-arm, ubuntu-24.04-riscv, windows-latest, windows-11-arm, macos-15-intel, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm, macos-15-intel, macos-latest]
 
     steps:
       - uses: actions/checkout@v5
@@ -64,7 +64,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, ubuntu-24.04-riscv, macos-15-intel, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-15-intel, macos-latest]
         # Can't really test with Windows because 'TcAdsDll.dll' will be missing
 
     steps:


### PR DESCRIPTION
## Summary
- The `ubuntu-24.04-riscv` job introduced in #522 never gets a runner assigned — it stays `queued` (runner_id 0) indefinitely until manually cancelled (observed during testing of #534/#533, ~35 min before cancellation)
- The repo's webhooks/integrations show no "RISE RISC-V Runner" marketplace app installed, which is the prerequisite step described in #520 ("Decide if it is acceptable to add access to the `ubuntu-24.04-riscv` runner by the RISE RISC-V Runner add-on...") — that step appears to have never been completed
- Since `build_wheels` feeds `test_wheels` and `upload_all`, a hung riscv job would block a real `release` from ever publishing to PyPI
- Remove `ubuntu-24.04-riscv` from both matrices until the marketplace runner integration is actually set up

Reopens #520 to revisit the marketplace app decision.

## Test plan
- [x] Verified no RISE runner integration is present (`gh api repos/stlehmann/pyads/hooks`)
- [ ] CI: `python-publish.yml` (workflow_dispatch) completes without any job stuck in `queued`