### PR TITLE
ci: use python -m pip in test_wheels to fix riscv64 pip launcher

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -78,9 +78,12 @@ jobs:
           python-version: "3.13"
 
       # Now install the package from the local wheels and try to use it:
+      # Use `python -m pip` instead of `pip` directly: on the riscv64 runner the
+      # `pip` console-script's shebang points at an interpreter path that doesn't
+      # exist, causing "cannot execute: required file not found".
       - run: |
-          pip install pyads --no-index --find-links ./dist
-          python -c "import pyads; pyads.Connection(ams_net_id='127.0.0.1.1.1', ams_net_port=851)" 
+          python -m pip install pyads --no-index --find-links ./dist
+          python -c "import pyads; pyads.Connection(ams_net_id='127.0.0.1.1.1', ams_net_port=851)"
 
   build_sdist:
     name: Build source distribution


### PR DESCRIPTION
The "Test distributions (ubuntu-24.04-riscv)" job in the
python-publish.yml release workflow fails with exit code 127:

  /opt/hostedtoolcache/Python/3.13.13/riscv64/bin/pip: cannot execute:
  required file not found

The pip console-script generated for the riscv64 Python build from
actions/setup-python has a shebang pointing at an interpreter path
that doesn't exist on that runner. Calling pip via `python -m pip`
avoids the broken launcher script entirely.