### PR TITLE
chore: update adslib submodule to 113.0.34-1 and rename adslib.so -> AdsLib.so

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ pyads - Python package
 [![Downloads](https://pepy.tech/badge/pyads/week)](https://pepy.tech/project/pyads)
 
 This is a python wrapper for TwinCATs ADS library. It provides python functions
-for communicating with TwinCAT devices. *pyads* uses the C API provided by *TcAdsDll.dll* on Windows *adslib.so* on Linux. The documentation for the ADS API is available on [infosys.beckhoff.com](https://infosys.beckhoff.com/content/1033/tc3_adsdll2/index.html?id=4279787267115190858).
+for communicating with TwinCAT devices. *pyads* uses the C API provided by *TcAdsDll.dll* on Windows *AdsLib.so* on Linux. The documentation for the ADS API is available on [infosys.beckhoff.com](https://infosys.beckhoff.com/content/1033/tc3_adsdll2/index.html?id=4279787267115190858).
 
 Documentation: http://pyads.readthedocs.io/en/latest/index.html
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -9,7 +9,7 @@ Welcome to pyads's documentation!
 This is a Python wrapper for TwinCATs ADS library. It aims to provide a
 pythonic way to communicate with TwinCAT devices by using the Python 
 programming language. pyads uses the C API provided by *TcAdsDll.dll* on 
-Windows and *adslib.so* on Linux. The Linux library is included in this
+Windows and *AdsLib.so* on Linux. The Linux library is included in this
 package.
 
 The documentation for the ADS API is available on `infosys.beckhoff.com`_.

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -24,9 +24,9 @@ Note: pyads only supports python 3.8 and above.
 
 ## Installation on Linux
 
-For Linux *pyads* uses the ADS library *adslib.so* which needs to be compiled
+For Linux *pyads* uses the ADS library *AdsLib.so* which needs to be compiled
 from source if you use a source package. This should not be an issue, however
-if you should encounter any problems with the *adslib.so* please contact me.
+if you should encounter any problems with the *AdsLib.so* please contact me.
 
 For the compilation to work you need to make sure `cmake` and `g++` are installed
 on your system.
@@ -57,9 +57,9 @@ carry on.
 >>> import pyads
 ```
 
-If you get an *OSError* saying that the *adslib.so* could not be found there
+If you get an *OSError* saying that the *AdsLib.so* could not be found there
 probably went something wrong with the build process of the shared library. In
-this case you can create the *adslib.so* manually by doing the following:
+this case you can create the *AdsLib.so* manually by doing the following:
 
 ```bash
 cd adslib
@@ -67,4 +67,4 @@ make
 sudo make install
 ```
 
-This compiles and places the *adslib.so* in your */usr/lib/* directory.
+This compiles and places the *AdsLib.so* in your */usr/lib/* directory.

--- a/setup.py
+++ b/setup.py
@@ -17,14 +17,14 @@ def _is_32bit_interpreter() -> bool:
 src_folder = Path(__file__).parent.absolute() / "src"
 # ^ This will be on PATH for editable install
 adslib_folder = Path(__file__).parent.absolute() / "adslib/build"
-adslib_file = src_folder / "adslib.so"
+adslib_file = src_folder / "AdsLib.so"
 
 
 def _adslib_shared_lib_name() -> str:
     """Return the shared library filename produced by meson/ninja."""
     if sys.platform.startswith("darwin"):
-        return "libadslib.dylib"
-    return "libadslib.so"
+        return "libAdsLib.dylib"
+    return "libAdsLib.so"
 
 
 class CustomBuildPy(build_py):
@@ -46,7 +46,7 @@ class CustomBuildPy(build_py):
     @staticmethod
     def _compile_library():
         """Use `make` to build adslib - build is done in-place."""
-        # Produce `adslib.so`:
+        # Produce `AdsLib.so`:
         os.chdir("adslib")
         env = os.environ.copy()
         env["BHF_ADS_EXPORT_C"] = "1"

--- a/src/pyads/pyads_ex.py
+++ b/src/pyads/pyads_ex.py
@@ -84,14 +84,14 @@ elif platform_is_linux():
     adslib_path = None
 
     for p in sys.path:
-        adslib_path = os.path.join(p, "adslib.so")
+        adslib_path = os.path.join(p, "AdsLib.so")
         if os.path.exists(adslib_path):
             break
 
     if adslib_path is None:
-        raise OSError(f"Failed to locate `adslib.so` library in {sys.path}")
+        raise OSError(f"Failed to locate `AdsLib.so` library in {sys.path}")
 
-    # For some reason loading on just "adslib.so" always fails, even if it is under
+    # For some reason loading on just "AdsLib.so" always fails, even if it is under
     # sys.path, so manually search for it first
     _adsDLL = ctypes.CDLL(adslib_path)
 


### PR DESCRIPTION
## Summary
- Bump the `adslib` submodule from `77953d58` (113.0.33-1) to `67886519` (113.0.34-1).
- Apply #531: rename references from `adslib.so` to `AdsLib.so` (README, docs, `setup.py`, `pyads_ex.py`) to match the renamed library output in upstream Beckhoff/ADS@ca978d7.
- Resolved a conflict in `setup.py` with the macOS `_adslib_shared_lib_name()` helper added in #534: it now returns `libAdsLib.so` / `libAdsLib.dylib`.

## Test plan
- [x] Built `adslib` via meson/ninja and confirmed `libAdsLib.so` is produced and packaged as `AdsLib.so`
- [x] `pip install .` into a clean venv succeeds and `AdsLib.so` is importable
- [x] `pytest` - 119 passed